### PR TITLE
docs: document private rules and helpers

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 docs/*.md
+docs/private/*.md

--- a/docs/private/BUILD.bazel
+++ b/docs/private/BUILD.bazel
@@ -1,0 +1,27 @@
+# This load statement must be in the docs/ package rather than anything users depend on
+# so that the dependency on stardoc doesn't leak to them.
+load("@aspect_bazel_lib//lib:docs.bzl", "stardoc_with_diff_test", "update_docs")
+
+stardoc_with_diff_test(
+    name = "settings",
+    bzl_library_target = "//zig/private:settings",
+)
+
+stardoc_with_diff_test(
+    name = "resolved_target_toolchain",
+    bzl_library_target = "//zig/private:resolved_target_toolchain",
+)
+
+stardoc_with_diff_test(
+    name = "resolved_toolchain",
+    bzl_library_target = "//zig/private:resolved_toolchain",
+)
+
+update_docs(name = "update")
+
+# workaround: update_docs does not allow to modify visibility.
+alias(
+    name = "update-alias",
+    actual = ":update",
+    visibility = ["//util:__pkg__"],
+)

--- a/docs/private/resolved_target_toolchain.md
+++ b/docs/private/resolved_target_toolchain.md
@@ -1,0 +1,26 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+This module implements an alias rule to the resolved target toolchain.
+
+
+<a id="resolved_target_toolchain"></a>
+
+## resolved_target_toolchain
+
+<pre>
+resolved_target_toolchain(<a href="#resolved_target_toolchain-name">name</a>)
+</pre>
+
+Exposes a concrete toolchain which is the result of Bazel resolving the
+toolchain for the execution or target platform.
+Workaround for https://github.com/bazelbuild/bazel/issues/14009
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="resolved_target_toolchain-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+
+

--- a/docs/private/resolved_toolchain.md
+++ b/docs/private/resolved_toolchain.md
@@ -1,0 +1,26 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+This module implements an alias rule to the resolved toolchain.
+
+
+<a id="resolved_toolchain"></a>
+
+## resolved_toolchain
+
+<pre>
+resolved_toolchain(<a href="#resolved_toolchain-name">name</a>)
+</pre>
+
+Exposes a concrete toolchain which is the result of Bazel resolving the
+toolchain for the execution or target platform.
+Workaround for https://github.com/bazelbuild/bazel/issues/14009
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="resolved_toolchain-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+
+

--- a/docs/private/settings.md
+++ b/docs/private/settings.md
@@ -1,0 +1,32 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+Implementation of the settings rule.
+
+<a id="settings"></a>
+
+## settings
+
+<pre>
+settings(<a href="#settings-name">name</a>, <a href="#settings-mode">mode</a>, <a href="#settings-threaded">threaded</a>)
+</pre>
+
+Collection of all Zig build settings.
+
+This rule is only intended for internal use.
+It collects the values of all relevant build settings,
+such as `@rules_zig//zig/settings:mode`.
+
+You can build the settings target to obtain a JSON file
+capturing all configured Zig build settings.
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="settings-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="settings-mode"></a>mode |  The build mode setting.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="settings-threaded"></a>threaded |  The Zig multi- or single-threaded setting.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+
+

--- a/util/BUILD.bazel
+++ b/util/BUILD.bazel
@@ -7,6 +7,7 @@ multirun(
         ":gazelle",
         ":update_filegroups",
         "//docs:update-alias",
+        "//docs/private:update-alias",
         "@contrib_rules_bazel_integration_test//tools:update_deleted_packages",
     ],
 )

--- a/zig/private/BUILD.bazel
+++ b/zig/private/BUILD.bazel
@@ -1,5 +1,15 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
+# For stardoc to reference the files
+exports_files(
+    [
+        "settings.bzl",
+        "resolved_target_toolchain.bzl",
+        "resolved_toolchain.bzl",
+    ],
+    visibility = ["//docs/private:__pkg__"],
+)
+
 bzl_library(
     name = "zig_package",
     srcs = ["zig_package.bzl"],
@@ -15,13 +25,6 @@ bzl_library(
     # Gazelle removes the srcs attribute for some reason.
     srcs = ["zig_test.bzl"],  # keep
     visibility = ["//zig:__subpackages__"],
-)
-
-bzl_library(
-    name = "settings",
-    srcs = ["settings.bzl"],
-    visibility = ["//zig:__subpackages__"],
-    deps = ["@bazel_skylib//rules:common_settings"],
 )
 
 bzl_library(
@@ -77,15 +80,34 @@ bzl_library(
 )
 
 bzl_library(
+    name = "settings",
+    srcs = ["settings.bzl"],
+    visibility = [
+        "//docs/private:__pkg__",  # keep
+        "//zig:__subpackages__",
+    ],
+    deps = [
+        "//zig/private/providers:zig_settings_info",
+        "@bazel_skylib//rules:common_settings",
+    ],
+)
+
+bzl_library(
     name = "resolved_target_toolchain",
     srcs = ["resolved_target_toolchain.bzl"],
-    visibility = ["//zig:__subpackages__"],
+    visibility = [
+        "//docs/private:__pkg__",  # keep
+        "//zig:__subpackages__",
+    ],
 )
 
 bzl_library(
     name = "resolved_toolchain",
     srcs = ["resolved_toolchain.bzl"],
-    visibility = ["//zig:__subpackages__"],
+    visibility = [
+        "//docs/private:__pkg__",  # keep
+        "//zig:__subpackages__",
+    ],
 )
 
 bzl_library(


### PR DESCRIPTION
Closes #65

- [x] document private rules
- [ ] document private helper functions
- [ ] fix BUILD file generation
  - Currently the `bzl_library` Gazelle extension forcefully overwrites
    `visibility`, ignoring `# keep` comments, meaning that the visibility of
    private `bzl_library` targets is too restrictive for Stardoc generation.


[bzl-gazelle]: https://github.com/bazelbuild/bazel-skylib/tree/caf2bc1ae197aea45aee80c2fd8845937097f00a/gazelle/bzl
