### PR TITLE
fix: root source file in progress message

### DIFF
--- a/zig/private/zig_binary.bzl
+++ b/zig/private/zig_binary.bzl
@@ -154,7 +154,7 @@ def _zig_binary_impl(ctx):
 
     ctx.actions.run(
         outputs = outputs,
-        inputs = depset(direct = direct_inputs, transitive = transitive_inputs),
+        inputs = depset(direct = direct_inputs, transitive = transitive_inputs, order = "preorder"),
         executable = zigtoolchaininfo.zig_exe_path,
         tools = zigtoolchaininfo.zig_files,
         arguments = ["build-exe", args],

--- a/zig/private/zig_library.bzl
+++ b/zig/private/zig_library.bzl
@@ -154,7 +154,7 @@ def _zig_library_impl(ctx):
 
     ctx.actions.run(
         outputs = outputs,
-        inputs = depset(direct = direct_inputs, transitive = transitive_inputs),
+        inputs = depset(direct = direct_inputs, transitive = transitive_inputs, order = "preorder"),
         executable = zigtoolchaininfo.zig_exe_path,
         tools = zigtoolchaininfo.zig_files,
         arguments = ["build-lib", args],

--- a/zig/private/zig_test.bzl
+++ b/zig/private/zig_test.bzl
@@ -153,7 +153,7 @@ def _zig_test_impl(ctx):
 
     ctx.actions.run(
         outputs = outputs,
-        inputs = depset(direct = direct_inputs, transitive = transitive_inputs),
+        inputs = depset(direct = direct_inputs, transitive = transitive_inputs, order = "preorder"),
         executable = zigtoolchaininfo.zig_exe_path,
         tools = zigtoolchaininfo.zig_files,
         arguments = ["test", "--test-no-exec", args],

--- a/zig/tests/package-binary/BUILD.bazel
+++ b/zig/tests/package-binary/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@rules_zig//zig:defs.bzl", "zig_binary", "zig_package")
+
+exports_files(
+    ["main.zig"],
+    visibility = ["//zig/tests:__pkg__"],
+)
+
+zig_package(
+    name = "data",
+    main = "data.zig",
+    visibility = ["//zig/tests:__pkg__"],
+)
+
+zig_binary(
+    name = "binary",
+    main = "main.zig",
+    visibility = ["//zig/tests:__pkg__"],
+    deps = [":data"],
+)

--- a/zig/tests/package-binary/data.zig
+++ b/zig/tests/package-binary/data.zig
@@ -1,0 +1,1 @@
+pub const hello_world = "Hello world!\n";

--- a/zig/tests/package-binary/main.zig
+++ b/zig/tests/package-binary/main.zig
@@ -1,0 +1,8 @@
+const std = @import("std");
+const data = @import("data");
+
+pub fn main() void {
+    std.io.getStdOut().writeAll(
+        data.hello_world,
+    ) catch unreachable;
+}


### PR DESCRIPTION
The progress message of a `zig_binary|library|test` build did not always display the correct root source file. For example, on targets with package dependencies one of the package dependencies' source file was listed instead.

This change fixes that by enforcing a preorder on the action inputs.

- Analysis test for progress message with package
- fix: set inputs order to preorder
