### PR TITLE
chore: factor out common Bazel config and use in e2e

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,36 +2,14 @@
 # Take care to document any settings that you expect users to apply.
 # Settings that apply only to CI are in .github/workflows/ci.bazelrc
 
+# Common configuration.
+impot %workspace%/.bazelrc.common
+
 # Zig build mode flag aliases. See further explanation in that file.
 import %workspace%/.bazelrc.flags
 
 # Remote cache configuration.
 import %workspace%/.bazelrc.remote
-
-# docs: https://bazel.build/reference/command-line-reference#flag--enable_bzlmod
-common --enable_bzlmod
-
-# docs: https://bazel.build/reference/command-line-reference#flag--incompatible_disallow_empty_glob
-common --incompatible_disallow_empty_glob
-
-# docs: https://bazel.build/reference/command-line-reference#flag--remote_upload_local_results
-build --noremote_upload_local_results
-# docs: https://bazel.build/reference/command-line-reference#flag--incompatible_remote_results_ignore_disk
-build --incompatible_remote_results_ignore_disk
-
-# docs: https://bazel.build/reference/command-line-reference#flag--incompatible_strict_action_env
-build --incompatible_strict_action_env
-# docs: https://bazel.build/reference/command-line-reference#flag--sandbox_default_allow_network
-build --sandbox_default_allow_network=false
-# docs: https://bazel.build/reference/command-line-reference#flag--legacy_external_runfiles
-build --nolegacy_external_runfiles
-
-# docs: https://bazel.build/reference/command-line-reference#flag--test_output
-test --test_output=errors
-# docs: https://bazel.build/reference/command-line-reference#flag--test_verbose_timeout_warnings
-test --test_verbose_timeout_warnings
-# docs: https://bazel.build/reference/command-line-reference#flag--incompatible_exclusive_test_sandboxed
-test --incompatible_exclusive_test_sandboxed
 
 # Deleted packages for integration tests.
 # To update these lines, execute

--- a/.bazelrc.common
+++ b/.bazelrc.common
@@ -1,0 +1,24 @@
+# docs: https://bazel.build/reference/command-line-reference#flag--enable_bzlmod
+common --enable_bzlmod
+
+# docs: https://bazel.build/reference/command-line-reference#flag--incompatible_disallow_empty_glob
+common --incompatible_disallow_empty_glob
+
+# docs: https://bazel.build/reference/command-line-reference#flag--remote_upload_local_results
+build --noremote_upload_local_results
+# docs: https://bazel.build/reference/command-line-reference#flag--incompatible_remote_results_ignore_disk
+build --incompatible_remote_results_ignore_disk
+
+# docs: https://bazel.build/reference/command-line-reference#flag--incompatible_strict_action_env
+build --incompatible_strict_action_env
+# docs: https://bazel.build/reference/command-line-reference#flag--sandbox_default_allow_network
+build --sandbox_default_allow_network=false
+# docs: https://bazel.build/reference/command-line-reference#flag--legacy_external_runfiles
+build --nolegacy_external_runfiles
+
+# docs: https://bazel.build/reference/command-line-reference#flag--test_output
+test --test_output=errors
+# docs: https://bazel.build/reference/command-line-reference#flag--test_verbose_timeout_warnings
+test --test_verbose_timeout_warnings
+# docs: https://bazel.build/reference/command-line-reference#flag--incompatible_exclusive_test_sandboxed
+test --incompatible_exclusive_test_sandboxed

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -113,7 +113,9 @@ jobs:
       - name: Set bzlmod flag
         # Set --enable_bzlmod if bzlmodEnabled is true, else --noenable_bzlmod.
         id: set_bzlmod_flag
-        run: echo "bzlmod_flag=${{ matrix.bzlmodEnabled && '--enable_bzlmod' || '--noenable_bzlmod' }}" >> $GITHUB_OUTPUT
+        run: |
+          echo "${{ matrix.bzlmodEnabled && '--enable_bzlmod' || '--noenable_bzlmod' }}" >> .bazelrc.user
+          echo "bzlmod_flag=${{ matrix.bzlmodEnabled && '--enable_bzlmod' || '--noenable_bzlmod' }}" >> $GITHUB_OUTPUT
 
       - name: Test generated files
         if: matrix.folder == '.' && matrix.target == '//...'
@@ -121,7 +123,7 @@ jobs:
           # Bazelisk will download bazel to here, ensure it is cached between runs.
           XDG_CACHE_HOME: ~/.cache/bazel-repo
         run: |
-          bazel --bazelrc=$GITHUB_WORKSPACE/.github/workflows/ci.bazelrc --bazelrc=.bazelrc run ${{ steps.set_bzlmod_flag.outputs.bzlmod_flag }} //util:update
+          bazel --bazelrc=$GITHUB_WORKSPACE/.github/workflows/ci.bazelrc --bazelrc=.bazelrc run //util:update
           test -z $(git status --porcelain) || { echo "Update generated files using `bazel run //util:update`" >&2; git diff >&2; exit 1; }
 
       - name: Check for test.sh
@@ -137,7 +139,7 @@ jobs:
           # Bazelisk will download bazel to here, ensure it is cached between runs.
           XDG_CACHE_HOME: ~/.cache/bazel-repo
         working-directory: ${{ matrix.folder }}
-        run: bazel --bazelrc=$GITHUB_WORKSPACE/.github/workflows/ci.bazelrc --bazelrc=.bazelrc test ${{ steps.set_bzlmod_flag.outputs.bzlmod_flag }} ${{ matrix.target }}
+        run: bazel --bazelrc=$GITHUB_WORKSPACE/.github/workflows/ci.bazelrc --bazelrc=.bazelrc test ${{ matrix.target }}
 
       - name: ./test.sh
         # Run if there is a test.sh file in the folder

--- a/e2e/workspace/.bazelrc
+++ b/e2e/workspace/.bazelrc
@@ -1,0 +1,4 @@
+# Configure Bazel for local testing
+try-import %workspace%/../../.bazelrc.common
+try-import %workspace%/../../.bazelrc.remote
+try-import %workspace%/.bazelrc.user

--- a/e2e/workspace/BUILD
+++ b/e2e/workspace/BUILD
@@ -27,6 +27,7 @@ build_test(
 
 diff_test(
     name = "zig_version_test",
+    size = "small",
     file1 = ":zig_version.expected",
     file2 = ":zig_version.actual",
 )

--- a/e2e/workspace/c-sources/BUILD.bazel
+++ b/e2e/workspace/c-sources/BUILD.bazel
@@ -18,6 +18,7 @@ zig_library(
 
 zig_test(
     name = "test",
+    size = "small",
     copts = ["-DNUMBER=42"],
     csrcs = ["symbol.c"],
     main = "main.zig",
@@ -25,6 +26,7 @@ zig_test(
 
 build_test(
     name = "build",
+    size = "small",
     targets = [
         ":binary",
         ":library",
@@ -41,6 +43,7 @@ genrule(
 
 diff_test(
     name = "output_test",
+    size = "small",
     file1 = ":output.expected",
     file2 = ":output.actual",
 )

--- a/e2e/workspace/configure-mode/BUILD.bazel
+++ b/e2e/workspace/configure-mode/BUILD.bazel
@@ -85,12 +85,14 @@ run(
 
 diff_test(
     name = "binary_debug_output_test",
+    size = "small",
     file1 = ":binary_debug_output.expected",
     file2 = ":binary_debug_output.actual",
 )
 
 diff_test(
     name = "binary_release_safe_output_test",
+    size = "small",
     file1 = ":binary_release_safe_output.expected",
     file2 = ":binary_release_safe_output.actual",
 )
@@ -103,6 +105,7 @@ zig_test(
 
 zig_configure_test(
     name = "test_debug",
+    size = "small",
     actual = "_test_debug",
     mode = "debug",
 )
@@ -115,6 +118,7 @@ zig_test(
 
 zig_configure_test(
     name = "test_release_safe",
+    size = "small",
     actual = "_test_release_safe",
     mode = "release_safe",
 )

--- a/e2e/workspace/configure-target/BUILD.bazel
+++ b/e2e/workspace/configure-target/BUILD.bazel
@@ -92,12 +92,14 @@ genrule(
 
 diff_test(
     name = "binary_aarch64-linux_arch_test",
+    size = "small",
     file1 = ":binary_aarch64-linux_arch.expected",
     file2 = ":binary_aarch64-linux_arch.actual",
 )
 
 diff_test(
     name = "binary_x86_64-windows_arch_test",
+    size = "small",
     file1 = ":binary_x86_64-windows_arch.expected",
     file2 = ":binary_x86_64-windows_arch.actual",
 )
@@ -159,12 +161,14 @@ genrule(
 
 diff_test(
     name = "test_aarch64-linux_arch_test",
+    size = "small",
     file1 = ":test_aarch64-linux_arch.expected",
     file2 = ":test_aarch64-linux_arch.actual",
 )
 
 diff_test(
     name = "test_x86_64-windows_arch_test",
+    size = "small",
     file1 = ":test_x86_64-windows_arch.expected",
     file2 = ":test_x86_64-windows_arch.actual",
 )

--- a/e2e/workspace/configure-threaded/BUILD.bazel
+++ b/e2e/workspace/configure-threaded/BUILD.bazel
@@ -85,12 +85,14 @@ run(
 
 diff_test(
     name = "binary_single_output_test",
+    size = "small",
     file1 = ":binary_single_output.expected",
     file2 = ":binary_single_output.actual",
 )
 
 diff_test(
     name = "binary_multi_output_test",
+    size = "small",
     file1 = ":binary_multi_output.expected",
     file2 = ":binary_multi_output.actual",
 )
@@ -103,6 +105,7 @@ zig_test(
 
 zig_configure_test(
     name = "test_single",
+    size = "small",
     actual = "_test_single",
     threaded = "single",
 )
@@ -115,6 +118,7 @@ zig_test(
 
 zig_configure_test(
     name = "test_multi",
+    size = "small",
     actual = "_test_multi",
     threaded = "multi",
 )

--- a/e2e/workspace/data-dependencies/BUILD.bazel
+++ b/e2e/workspace/data-dependencies/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_zig//zig:defs.bzl", "zig_package", "zig_test")
 
 zig_test(
     name = "direct-data",
+    size = "small",
     data = ["data.txt"],
     main = "direct-data.zig",
 )
@@ -14,6 +15,7 @@ zig_package(
 
 zig_test(
     name = "direct-package-data",
+    size = "small",
     main = "direct-package-data.zig",
     deps = [":direct-package"],
 )
@@ -26,6 +28,7 @@ zig_package(
 
 zig_test(
     name = "indirect-package-data",
+    size = "small",
     main = "indirect-package-data.zig",
     deps = [":indirect-package"],
 )

--- a/e2e/workspace/embed-file/BUILD.bazel
+++ b/e2e/workspace/embed-file/BUILD.bazel
@@ -16,6 +16,7 @@ zig_library(
 
 zig_test(
     name = "test",
+    size = "small",
     extra_srcs = ["message.txt"],
     main = "main.zig",
 )
@@ -28,6 +29,7 @@ zig_package(
 
 zig_test(
     name = "test-with-package",
+    size = "small",
     main = "test-with-package.zig",
     deps = [":package"],
 )
@@ -51,6 +53,7 @@ genrule(
 
 diff_test(
     name = "output_test",
+    size = "small",
     file1 = ":output.expected",
     file2 = ":output.actual",
 )

--- a/e2e/workspace/linker-script/BUILD.bazel
+++ b/e2e/workspace/linker-script/BUILD.bazel
@@ -19,6 +19,7 @@ genrule(
 
 diff_test(
     name = "bin_output_test",
+    size = "small",
     file1 = ":bin_output.expected",
     file2 = ":bin_output.actual",
     target_compatible_with = ["@platforms//os:linux"],
@@ -41,6 +42,7 @@ build_test(
 
 zig_test(
     name = "test",
+    size = "small",
     linker_script = "custom.ld",
     main = "test.zig",
     target_compatible_with = ["@platforms//os:linux"],

--- a/e2e/workspace/multiple-sources-and-packages-test/BUILD.bazel
+++ b/e2e/workspace/multiple-sources-and-packages-test/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_zig//zig:defs.bzl", "zig_package", "zig_test")
 
 zig_test(
     name = "test",
+    size = "small",
     srcs = [
         "test/a.zig",
         "test/b.zig",

--- a/e2e/workspace/multiple-sources-binary/BUILD.bazel
+++ b/e2e/workspace/multiple-sources-binary/BUILD.bazel
@@ -21,6 +21,7 @@ genrule(
 
 diff_test(
     name = "output_test",
+    size = "small",
     file1 = ":output.expected",
     file2 = ":output.actual",
 )

--- a/e2e/workspace/simple-binary/BUILD.bazel
+++ b/e2e/workspace/simple-binary/BUILD.bazel
@@ -15,6 +15,7 @@ genrule(
 
 diff_test(
     name = "output_test",
+    size = "small",
     file1 = ":output.expected",
     file2 = ":output.actual",
 )

--- a/e2e/workspace/simple-test/BUILD.bazel
+++ b/e2e/workspace/simple-test/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_zig//zig:defs.bzl", "zig_test")
 
 zig_test(
     name = "succeeds",
+    size = "small",
     main = "succeeding-test.zig",
 )
 
@@ -16,6 +17,7 @@ genrule(
 
 diff_test(
     name = "success_result_test",
+    size = "small",
     file1 = ":success_result.expected",
     file2 = ":success_result.actual",
 )
@@ -36,6 +38,7 @@ genrule(
 
 diff_test(
     name = "failure_result_test",
+    size = "small",
     file1 = ":failure_result.expected",
     file2 = ":failure_result.actual",
 )

--- a/e2e/workspace/transitive-zig-packages-binary/BUILD.bazel
+++ b/e2e/workspace/transitive-zig-packages-binary/BUILD.bazel
@@ -18,6 +18,7 @@ genrule(
 
 diff_test(
     name = "output_test",
+    size = "small",
     file1 = ":output.expected",
     file2 = ":output.actual",
 )

--- a/e2e/workspace/zig-package-binary/BUILD.bazel
+++ b/e2e/workspace/zig-package-binary/BUILD.bazel
@@ -19,6 +19,7 @@ genrule(
 
 diff_test(
     name = "output_test",
+    size = "small",
     file1 = ":output.expected",
     file2 = ":output.actual",
 )


### PR DESCRIPTION
- factor out common config and use it in e2e too
- Size test size attributes in e2e tests
- Configure bzlmod in .bazelrc.user
