### PR TITLE
docs: Install instructions and status in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,6 @@ Build [Zig code][zig] with the [Bazel build system][bazel].
 
 ## Status
 
-🚧 This is a hobby project in early development. 🚧
-
-Please [get in touch](https://github.com/aherrmann) if you would like to use
-these rules in production.
-
 Take a look at the [planned functionality][planned-functionality] tracking
 issue to get a picture of which functionality is already implemented and what
 is still missing.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,20 @@ and build configuration features well.
 
 ## Installation
 
+The instructions assume basic familiarity with the Bazel build system.
+Take a look at [Bazel's documentation][bazel-intro] if you are unfamiliar.
+
+[bazel-intro]: https://bazel.build/about/intro
+
 ### Using Bzlmod with Bazel >=6
+
+Bzlmod is Bazel's new dependency manager. You can read more about it in the
+[Bazel documentation][bzlmod-doc]. If you use bzlmod, then you can skip the
+WORKSPACE section below. Take a look at [Bazel's migration
+guide][bzlmod-migration] if you are switching from WORKSPACE to bzlmod.
+
+[bzlmod-doc]: https://bazel.build/external/overview#bzlmod
+[bzlmod-migration]: https://bazel.build/external/migration
 
 Add the following to your MODULE.bazel file to install rules_zig:
 
@@ -65,7 +78,20 @@ archive_override(
 )
 ```
 
+Note, `$SHA256` and `$COMMIT` are placeholders that you need to fill in. Take a
+look at the [Bazel documentation][archive-override-doc] for further
+information.
+
+[archive-override-doc]: https://bazel.build/versions/6.4.0/rules/lib/globals#archive_override
+
 ### Using WORKSPACE
+
+The old way of managing external dependencies with Bazel is to declare them in
+your WORKSPACE file. You can read more about it in the [Bazel
+documentation][workspace-doc]. If you use the WORKSPACE approach, then you can
+skip the bzlmod section above.
+
+[workspace-doc]: https://bazel.build/external/overview#workspace-system
 
 Add the following to your WORKSPACE file to install rules_zig:
 
@@ -92,6 +118,12 @@ zig_register_toolchains(
     zig_version = "0.11.0",
 )
 ```
+
+Note, `$SHA256` and `$COMMIT` are placeholders that you need to fill in. Take a
+look at the [Bazel documentation][http-archive-doc] for further
+information.
+
+[http-archive-doc]: https://bazel.build/rules/lib/repo/http#http_archive
 
 <!-- TODO[AH] Point to release installation instructions
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,12 @@ guide][bzlmod-migration] if you are switching from WORKSPACE to bzlmod.
 [bzlmod-doc]: https://bazel.build/external/overview#bzlmod
 [bzlmod-migration]: https://bazel.build/external/migration
 
-Add the following to your MODULE.bazel file to install rules_zig:
+To install a [release version of rules_zig][rules-zig-releases] follow the
+installation instructions given in the corresponding release notes.
+
+[rules-zig-releases]: https://github.com/aherrmann/rules_zig/releases
+
+To install a development version add the following to your MODULE.bazel file:
 
 ```bzl
 bazel_dep(name = "rules_zig")
@@ -93,7 +98,10 @@ skip the bzlmod section above.
 
 [workspace-doc]: https://bazel.build/external/overview#workspace-system
 
-Add the following to your WORKSPACE file to install rules_zig:
+To install a [release version of rules_zig][rules-zig-releases] follow the
+installation instructions given in the corresponding release notes.
+
+To install a development version add the following to your WORKSPACE file:
 
 ```bzl
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
@@ -124,14 +132,6 @@ look at the [Bazel documentation][http-archive-doc] for further
 information.
 
 [http-archive-doc]: https://bazel.build/rules/lib/repo/http#http_archive
-
-<!-- TODO[AH] Point to release installation instructions
-
-From the release you wish to use:
-<https://github.com/aherrmann/rules_zig/releases>
-copy the WORKSPACE snippet into your `WORKSPACE` file.
-
--->
 
 <!-- TODO[AH] Write a user-guide
   https://github.com/aherrmann/rules_zig/issues/59

--- a/README.md
+++ b/README.md
@@ -140,11 +140,6 @@ copy the WORKSPACE snippet into your `WORKSPACE` file.
 
 -->
 
-## Reference Documentation
-
-Generated API documentation for the provided rules is available in
-[`./docs/rules.md`](./docs/rules.md).
-
 ## Usage Examples
 
 <!-- TODO[AH] Create an instructive example.
@@ -153,3 +148,8 @@ Generated API documentation for the provided rules is available in
 
 Examples can be found among the end-to-end tests under
 [`./e2e/workspace`](./e2e/workspace).
+
+## Reference Documentation
+
+Generated API documentation for the provided rules is available in
+[`./docs/rules.md`](./docs/rules.md).


### PR DESCRIPTION
- Expand the installation instructions
- Document examples before reference docs
- Refer to release notes for install instructions
- Remove the early development warning
