### PR TITLE
feat: non-allocating variant of rlocation

### DIFF
--- a/e2e/workspace/runfiles-library/dependency/main.zig
+++ b/e2e/workspace/runfiles-library/dependency/main.zig
@@ -8,7 +8,7 @@ pub fn readData(allocator: std.mem.Allocator) ![]const u8 {
 
     const rpath = "runfiles_library_transitive_dependency/data.txt";
 
-    const file_path = try r.rlocation(allocator, rpath, bazel_builtin.current_repository) orelse
+    const file_path = try r.rlocationAlloc(allocator, rpath, bazel_builtin.current_repository) orelse
         return error.RLocationNotFound;
     defer allocator.free(file_path);
 

--- a/e2e/workspace/runfiles-library/main.zig
+++ b/e2e/workspace/runfiles-library/main.zig
@@ -20,7 +20,7 @@ pub fn main() !void {
     const rpath = try getEnvVar(allocator, "DATA") orelse return error.EnvVarNotFoundDATA;
     defer allocator.free(rpath);
 
-    const file_path = try r.rlocation(allocator, rpath, "") orelse return error.RLocationNotFound;
+    const file_path = try r.rlocationAlloc(allocator, rpath, "") orelse return error.RLocationNotFound;
     defer allocator.free(file_path);
 
     var file = try std.fs.cwd().openFile(file_path, .{});
@@ -39,7 +39,7 @@ test "read data file" {
     const rpath = try getEnvVar(std.testing.allocator, "DATA") orelse return error.EnvVarNotFoundDATA;
     defer std.testing.allocator.free(rpath);
 
-    const file_path = try r.rlocation(std.testing.allocator, rpath, "") orelse return error.RLocationNotFound;
+    const file_path = try r.rlocationAlloc(std.testing.allocator, rpath, "") orelse return error.RLocationNotFound;
     defer std.testing.allocator.free(file_path);
 
     var file = try std.fs.cwd().openFile(file_path, .{});
@@ -58,7 +58,7 @@ test "resolve external dependency rpath" {
     const rpath = try getEnvVar(std.testing.allocator, "DEPENDENCY_DATA") orelse return error.EnvVarNotFoundDEPENDENCY_DATA;
     defer std.testing.allocator.free(rpath);
 
-    const file_path = try r.rlocation(std.testing.allocator, rpath, "") orelse return error.RLocationNotFound;
+    const file_path = try r.rlocationAlloc(std.testing.allocator, rpath, "") orelse return error.RLocationNotFound;
     defer std.testing.allocator.free(file_path);
 
     var file = try std.fs.cwd().openFile(file_path, .{});

--- a/zig/runfiles/src/Directory.zig
+++ b/zig/runfiles/src/Directory.zig
@@ -22,7 +22,7 @@ pub fn deinit(self: *Directory, allocator: std.mem.Allocator) void {
     allocator.free(self.path);
 }
 
-pub fn rlocationUnmapped(
+pub fn rlocationUnmappedAlloc(
     self: *const Directory,
     allocator: std.mem.Allocator,
     rpath: RPath,
@@ -53,7 +53,7 @@ test "Directory init and unmapped lookup" {
     defer directory.deinit(std.testing.allocator);
 
     {
-        const filepath = try directory.rlocationUnmapped(std.testing.allocator, .{
+        const filepath = try directory.rlocationUnmappedAlloc(std.testing.allocator, .{
             .repo = "",
             .path = "_repo_mapping",
         });
@@ -68,7 +68,7 @@ test "Directory init and unmapped lookup" {
     }
 
     {
-        const filepath = try directory.rlocationUnmapped(std.testing.allocator, .{
+        const filepath = try directory.rlocationUnmappedAlloc(std.testing.allocator, .{
             .repo = "my_workspace",
             .path = "some/package/some_file",
         });

--- a/zig/runfiles/src/Directory.zig
+++ b/zig/runfiles/src/Directory.zig
@@ -22,6 +22,21 @@ pub fn deinit(self: *Directory, allocator: std.mem.Allocator) void {
     allocator.free(self.path);
 }
 
+pub fn rlocationUnmapped(
+    self: *const Directory,
+    rpath: RPath,
+    out_buffer: []u8,
+) ![]const u8 {
+    var stream = std.io.fixedBufferStream(out_buffer);
+    // TODO[AH] Implement OS specific normalization, e.g. Windows lower-case.
+    try stream.writer().writeAll(self.path);
+    if (rpath.repo.len > 0)
+        try stream.writer().print("/{s}", .{rpath.repo});
+    if (rpath.path.len > 0)
+        try stream.writer().print("/{s}", .{rpath.path});
+    return stream.getWritten();
+}
+
 pub fn rlocationUnmappedAlloc(
     self: *const Directory,
     allocator: std.mem.Allocator,

--- a/zig/runfiles/src/Runfiles.zig
+++ b/zig/runfiles/src/Runfiles.zig
@@ -87,7 +87,7 @@ pub fn rlocationAlloc(
             // pattern.
         }
     }
-    return try self.implementation.rlocationUnmapped(allocator, .{
+    return try self.implementation.rlocationUnmappedAlloc(allocator, .{
         .repo = repo,
         .path = path,
     });
@@ -104,7 +104,7 @@ const Implementation = union(discovery.Strategy) {
         }
     }
 
-    pub fn rlocationUnmapped(
+    pub fn rlocationUnmappedAlloc(
         self: *const Implementation,
         allocator: std.mem.Allocator,
         rpath: RPath,
@@ -116,7 +116,7 @@ const Implementation = union(discovery.Strategy) {
                 return try allocator.dupe(u8, path);
             },
             .directory => |*directory| {
-                return try directory.rlocationUnmapped(allocator, rpath);
+                return try directory.rlocationUnmappedAlloc(allocator, rpath);
             },
         }
     }
@@ -126,7 +126,7 @@ const Implementation = union(discovery.Strategy) {
         const msg_not_found = "No repository mapping found. " ++
             "This is likely an error if you are using Bazel version >=7 with bzlmod enabled.";
 
-        const path = try self.rlocationUnmapped(allocator, .{
+        const path = try self.rlocationUnmappedAlloc(allocator, .{
             .repo = "",
             .path = repo_mapping_file_name,
         }) orelse {

--- a/zig/runfiles/src/Runfiles.zig
+++ b/zig/runfiles/src/Runfiles.zig
@@ -66,6 +66,18 @@ pub fn deinit(self: *Runfiles, allocator: std.mem.Allocator) void {
 ///
 /// TODO: Path normalization, in particular lower-case and '/' normalization on
 ///   Windows, is not yet implemented.
+pub fn rlocation(
+    self: *const Runfiles,
+    rpath: []const u8,
+    source: []const u8,
+    out_buffer: []u8,
+) !?[]const u8 {
+    const rpath_ = self.remapRPath(rpath, source);
+    return try self.implementation.rlocationUnmapped(out_buffer, rpath_);
+}
+
+/// Allocating variant of `rlocation`.
+/// The caller owns the returned path.
 pub fn rlocationAlloc(
     self: *const Runfiles,
     allocator: std.mem.Allocator,

--- a/zig/runfiles/src/Runfiles.zig
+++ b/zig/runfiles/src/Runfiles.zig
@@ -66,7 +66,7 @@ pub fn deinit(self: *Runfiles, allocator: std.mem.Allocator) void {
 ///
 /// TODO: Path normalization, in particular lower-case and '/' normalization on
 ///   Windows, is not yet implemented.
-pub fn rlocation(
+pub fn rlocationAlloc(
     self: *const Runfiles,
     allocator: std.mem.Allocator,
     rpath: []const u8,
@@ -175,7 +175,7 @@ test "Runfiles from manifest" {
     defer runfiles.deinit(std.testing.allocator);
 
     {
-        const file_path = try runfiles.rlocation(
+        const file_path = try runfiles.rlocationAlloc(
             std.testing.allocator,
             "my_module/some/package/some_file",
             "",
@@ -189,7 +189,7 @@ test "Runfiles from manifest" {
     }
 
     {
-        const file_path = try runfiles.rlocation(
+        const file_path = try runfiles.rlocationAlloc(
             std.testing.allocator,
             "other_module/other/package/other_file",
             "",
@@ -203,7 +203,7 @@ test "Runfiles from manifest" {
     }
 
     {
-        const file_path = try runfiles.rlocation(
+        const file_path = try runfiles.rlocationAlloc(
             std.testing.allocator,
             "another_module/other/package/other_file",
             "their_module~1.2.3",
@@ -264,7 +264,7 @@ test "Runfiles from directory" {
     defer runfiles.deinit(std.testing.allocator);
 
     {
-        const file_path = try runfiles.rlocation(
+        const file_path = try runfiles.rlocationAlloc(
             std.testing.allocator,
             "my_module/some/package/some_file",
             "",
@@ -278,7 +278,7 @@ test "Runfiles from directory" {
     }
 
     {
-        const file_path = try runfiles.rlocation(
+        const file_path = try runfiles.rlocationAlloc(
             std.testing.allocator,
             "other_module/other/package/other_file",
             "",
@@ -292,7 +292,7 @@ test "Runfiles from directory" {
     }
 
     {
-        const file_path = try runfiles.rlocation(
+        const file_path = try runfiles.rlocationAlloc(
             std.testing.allocator,
             "another_module/other/package/other_file",
             "their_module~1.2.3",

--- a/zig/runfiles/src/Runfiles.zig
+++ b/zig/runfiles/src/Runfiles.zig
@@ -73,7 +73,7 @@ pub fn rlocation(
     out_buffer: []u8,
 ) !?[]const u8 {
     const rpath_ = self.remapRPath(rpath, source);
-    return try self.implementation.rlocationUnmapped(out_buffer, rpath_);
+    return try self.implementation.rlocationUnmapped(rpath_, out_buffer);
 }
 
 /// Allocating variant of `rlocation`.
@@ -116,8 +116,8 @@ const Implementation = union(discovery.Strategy) {
 
     pub fn rlocationUnmapped(
         self: *const Implementation,
-        out_buffer: []u8,
         rpath: RPath,
+        out_buffer: []u8,
     ) !?[]const u8 {
         switch (self.*) {
             .manifest => |*manifest| {
@@ -130,7 +130,7 @@ const Implementation = union(discovery.Strategy) {
                 return result;
             },
             .directory => |*directory| {
-                return try directory.rlocationUnmapped(out_buffer, rpath);
+                return try directory.rlocationUnmapped(rpath, out_buffer);
             },
         }
     }

--- a/zig/runfiles/src/Runfiles.zig
+++ b/zig/runfiles/src/Runfiles.zig
@@ -206,13 +206,13 @@ test "Runfiles from manifest" {
     defer runfiles.deinit(std.testing.allocator);
 
     {
-        const file_path = try runfiles.rlocationAlloc(
-            std.testing.allocator,
+        var buffer: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+        const file_path = try runfiles.rlocation(
             "my_module/some/package/some_file",
             "",
+            &buffer,
         ) orelse
             return error.TestRLocationNotFound;
-        defer std.testing.allocator.free(file_path);
         try std.testing.expect(std.fs.path.isAbsolute(file_path));
         const content = try std.fs.cwd().readFileAlloc(std.testing.allocator, file_path, 4096);
         defer std.testing.allocator.free(content);
@@ -295,13 +295,13 @@ test "Runfiles from directory" {
     defer runfiles.deinit(std.testing.allocator);
 
     {
-        const file_path = try runfiles.rlocationAlloc(
-            std.testing.allocator,
+        var buffer: [std.fs.MAX_PATH_BYTES]u8 = undefined;
+        const file_path = try runfiles.rlocation(
             "my_module/some/package/some_file",
             "",
+            &buffer,
         ) orelse
             return error.TestRLocationNotFound;
-        defer std.testing.allocator.free(file_path);
         try std.testing.expect(std.fs.path.isAbsolute(file_path));
         const content = try std.fs.cwd().readFileAlloc(std.testing.allocator, file_path, 4096);
         defer std.testing.allocator.free(content);

--- a/zig/runfiles/src/Runfiles.zig
+++ b/zig/runfiles/src/Runfiles.zig
@@ -104,6 +104,27 @@ const Implementation = union(discovery.Strategy) {
         }
     }
 
+    pub fn rlocationUnmapped(
+        self: *const Implementation,
+        out_buffer: []u8,
+        rpath: RPath,
+    ) !?[]const u8 {
+        switch (self.*) {
+            .manifest => |*manifest| {
+                const path = manifest.rlocationUnmapped(rpath) orelse
+                    return null;
+                if (path.len > out_buffer.len)
+                    return error.NameTooLong;
+                const result = out_buffer[0..path.len];
+                @memcpy(result, path);
+                return result;
+            },
+            .directory => |*directory| {
+                return try directory.rlocationUnmapped(out_buffer, rpath);
+            },
+        }
+    }
+
     pub fn rlocationUnmappedAlloc(
         self: *const Implementation,
         allocator: std.mem.Allocator,

--- a/zig/tests/integration_tests/workspace/runfiles/main.zig
+++ b/zig/tests/integration_tests/workspace/runfiles/main.zig
@@ -13,7 +13,7 @@ pub fn main() !void {
 
     const rpath = "__main__/runfiles/data.txt";
 
-    const file_path = try r.rlocation(allocator, rpath, bazel_builtin.current_repository) orelse {
+    const file_path = try r.rlocationAlloc(allocator, rpath, bazel_builtin.current_repository) orelse {
         std.log.err("Runfiles location '{s}' not found", .{rpath});
         return error.RLocationNotFound;
     };


### PR DESCRIPTION
Part of #86

- Explicit alloc: rlocation --> rlocationAlloc
- rlocationUnmapped --> rlocationUnmappedAlloc
- non-allocating rlocation function
- Use RPath.init for rpath repo splitting
- Factor out rpath remapping
- Add non-allocating variant of rlocation
- Consistent out_buffer argument position
- Test non-allocating rlocation variant
