### PR TITLE
feat: expose runfiles environment variables

### DIFF
--- a/e2e/workspace/runfiles-library/BUILD.bazel
+++ b/e2e/workspace/runfiles-library/BUILD.bazel
@@ -29,9 +29,11 @@ zig_test(
     size = "small",
     data = [
         "data.txt",
+        ":binary",
         "@runfiles_library_dependency//:data.txt",
     ],
     env = {
+        "BINARY": "$(rlocationpath :binary)",
         "DATA": "$(rlocationpath data.txt)",
         # Intentionally not using $(rlocation ...) to test repo-mapping.
         "DEPENDENCY_DATA": "runfiles_library_dependency/data.txt",

--- a/zig/runfiles/src/Runfiles.zig
+++ b/zig/runfiles/src/Runfiles.zig
@@ -260,6 +260,14 @@ test "Runfiles from manifest" {
         defer std.testing.allocator.free(content);
         try std.testing.expectEqualStrings("other_content", content);
     }
+
+    {
+        var env = std.process.EnvMap.init(std.testing.allocator);
+        defer env.deinit();
+        try runfiles.environment(&env);
+        try std.testing.expectEqual(@as(usize, 1), env.count());
+        try std.testing.expectEqualStrings(manifest_path, env.get(discovery.runfiles_manifest_var_name).?);
+    }
 }
 
 test "Runfiles from directory" {
@@ -348,5 +356,13 @@ test "Runfiles from directory" {
         const content = try std.fs.cwd().readFileAlloc(std.testing.allocator, file_path, 4096);
         defer std.testing.allocator.free(content);
         try std.testing.expectEqualStrings("other_content", content);
+    }
+
+    {
+        var env = std.process.EnvMap.init(std.testing.allocator);
+        defer env.deinit();
+        try runfiles.environment(&env);
+        try std.testing.expectEqual(@as(usize, 1), env.count());
+        try std.testing.expectEqualStrings(directory_path, env.get(discovery.runfiles_directory_var_name).?);
     }
 }

--- a/zig/runfiles/src/Runfiles.zig
+++ b/zig/runfiles/src/Runfiles.zig
@@ -88,6 +88,13 @@ pub fn rlocationAlloc(
     return try self.implementation.rlocationUnmappedAlloc(allocator, rpath_);
 }
 
+/// Set the required environment variables to discover the same runfiles. Use
+/// this if you invoke another process that needs to resolve runfiles location
+/// paths.
+pub fn environment(self: *const Runfiles, output_env: *std.process.EnvMap) !void {
+    try self.implementation.environment(output_env);
+}
+
 fn remapRPath(self: *const Runfiles, rpath: []const u8, source: []const u8) RPath {
     var rpath_ = RPath.init(rpath);
     if (self.repo_mapping) |repo_mapping| {
@@ -149,6 +156,13 @@ const Implementation = union(discovery.Strategy) {
             .directory => |*directory| {
                 return try directory.rlocationUnmappedAlloc(allocator, rpath);
             },
+        }
+    }
+
+    pub fn environment(self: *const Implementation, output_env: *std.process.EnvMap) !void {
+        switch (self.*) {
+            .manifest => |*manifest| try output_env.put(discovery.runfiles_manifest_var_name, manifest.path),
+            .directory => |*directory| try output_env.put(discovery.runfiles_directory_var_name, directory.path),
         }
     }
 


### PR DESCRIPTION
Part of #86

Bazel merges runfiles at the top-level. If nested processes need to access runfiles, then the environment must contain the relevant varibles to point to the top-level runfiles manifest or directory.

- runfiles manifest: remember path
- Expose the runfiles environment variables
- Unit test runfiles directory
- e2e test: nested binary runfiles
