### PR TITLE
fix: resolve zig-autodoc-guide correctly

### DIFF
--- a/e2e/workspace/zig-docs/main.zig
+++ b/e2e/workspace/zig-docs/main.zig
@@ -1,7 +1,4 @@
-// TODO[AH] The `../` prefix is necessary for Zig to find the guide.
-//   That may be a bug in Zig autodoc, looking at strace it attempts to open
-//   `zig-docs/guide.md` from within the `zig-docs` directory.
-//!zig-autodoc-guide: ../guide.md
+//!zig-autodoc-guide: guide.md
 
 const std = @import("std");
 pub const hello_world = @import("hello_world");

--- a/zig/private/common/zig_build.bzl
+++ b/zig/private/common/zig_build.bzl
@@ -199,6 +199,8 @@ def zig_build_impl(ctx, *, kind):
     direct_inputs.append(ctx.file.main)
     direct_inputs.extend(ctx.files.srcs)
     direct_inputs.extend(ctx.files.extra_srcs)
+
+    args.add_all(["--main-pkg-path", "."])
     args.add(ctx.file.main)
 
     location_targets = ctx.attr.data

--- a/zig/private/common/zig_docs.bzl
+++ b/zig/private/common/zig_docs.bzl
@@ -68,6 +68,8 @@ def zig_docs_impl(ctx, *, kind):
     direct_inputs.extend(ctx.files.srcs)
     direct_inputs.extend(ctx.files.extra_srcs)
     direct_inputs.extend(ctx.files.extra_docs)
+
+    args.add_all(["--main-pkg-path", "."])
     args.add(ctx.file.main)
 
     location_targets = ctx.attr.data


### PR DESCRIPTION
Set the `--main-pkg-path` flag to `.` (the execution root).

- fix: Set the --main-pkg-path flag
- fix: e2e docs test autodocs guide path
