### PR TITLE
docs: runfiles library user guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,3 +148,8 @@ Examples can be found among the end-to-end tests under
 
 Generated API documentation for the provided rules is available in
 [`./docs/rules.md`](./docs/rules.md).
+
+## Runfiles Library Documentation
+
+Documentation for the Zig runfiles library can be found in
+[`./zig/runfiles/guide.md`](./zig/runfiles/guide.md).

--- a/e2e/workspace/runfiles-library/BUILD.bazel
+++ b/e2e/workspace/runfiles-library/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
 load("@rules_zig//zig:defs.bzl", "zig_binary", "zig_test")
 
@@ -45,9 +46,15 @@ zig_test(
     ],
 )
 
+build_test(
+    name = "runfiles-docs-build-test",
+    targets = ["@rules_zig//zig/runfiles:docs"],
+)
+
 test_suite(
     name = "runfiles-library",
     tests = [
+        ":runfiles-docs-build-test",
         ":test",
         "@runfiles_library_dependency//:test",
     ],

--- a/e2e/workspace/runfiles-library/BUILD.bazel
+++ b/e2e/workspace/runfiles-library/BUILD.bazel
@@ -36,7 +36,7 @@ zig_test(
     env = {
         "BINARY": "$(rlocationpath :binary)",
         "DATA": "$(rlocationpath data.txt)",
-        # Intentionally not using $(rlocation ...) to test repo-mapping.
+        # Intentionally not using $(rlocationpath ...) to test repo-mapping.
         "DEPENDENCY_DATA": "runfiles_library_dependency/data.txt",
     },
     main = "main.zig",

--- a/e2e/workspace/runfiles-library/dependency/main.zig
+++ b/e2e/workspace/runfiles-library/dependency/main.zig
@@ -3,7 +3,8 @@ const runfiles = @import("runfiles");
 const bazel_builtin = @import("bazel_builtin");
 
 pub fn readData(allocator: std.mem.Allocator) ![]const u8 {
-    var r = try runfiles.Runfiles.create(.{ .allocator = allocator });
+    var r = try runfiles.Runfiles.create(.{ .allocator = allocator }) orelse
+        return error.RunfilesNotFound;
     defer r.deinit(allocator);
 
     const rpath = "runfiles_library_transitive_dependency/data.txt";

--- a/e2e/workspace/runfiles-library/main.zig
+++ b/e2e/workspace/runfiles-library/main.zig
@@ -14,7 +14,8 @@ pub fn main() !void {
 
     const allocator = arena.allocator();
 
-    var r = try runfiles.Runfiles.create(.{ .allocator = allocator });
+    var r = try runfiles.Runfiles.create(.{ .allocator = allocator }) orelse
+        return error.RunfilesNotFound;
     defer r.deinit(allocator);
 
     const rpath = try getEnvVar(allocator, "DATA") orelse return error.EnvVarNotFoundDATA;
@@ -33,7 +34,8 @@ pub fn main() !void {
 }
 
 test "read data file" {
-    var r = try runfiles.Runfiles.create(.{ .allocator = std.testing.allocator });
+    var r = try runfiles.Runfiles.create(.{ .allocator = std.testing.allocator }) orelse
+        return error.RunfilesNotFound;
     defer r.deinit(std.testing.allocator);
 
     const rpath = try getEnvVar(std.testing.allocator, "DATA") orelse return error.EnvVarNotFoundDATA;
@@ -52,7 +54,8 @@ test "read data file" {
 }
 
 test "resolve external dependency rpath" {
-    var r = try runfiles.Runfiles.create(.{ .allocator = std.testing.allocator });
+    var r = try runfiles.Runfiles.create(.{ .allocator = std.testing.allocator }) orelse
+        return error.RunfilesNotFound;
     defer r.deinit(std.testing.allocator);
 
     const rpath = try getEnvVar(std.testing.allocator, "DEPENDENCY_DATA") orelse return error.EnvVarNotFoundDEPENDENCY_DATA;
@@ -78,7 +81,8 @@ test "read data file in dependency Zig package" {
 }
 
 test "runfiles in nested binary" {
-    var r = try runfiles.Runfiles.create(.{ .allocator = std.testing.allocator });
+    var r = try runfiles.Runfiles.create(.{ .allocator = std.testing.allocator }) orelse
+        return error.RunfilesNotFound;
     defer r.deinit(std.testing.allocator);
 
     const rpath = try getEnvVar(std.testing.allocator, "BINARY") orelse return error.EnvVarNotFoundBINARY;

--- a/zig/runfiles/BUILD.bazel
+++ b/zig/runfiles/BUILD.bazel
@@ -1,4 +1,9 @@
-load("@rules_zig//zig:defs.bzl", "zig_package", "zig_test")
+load(
+    "@rules_zig//zig:defs.bzl",
+    "zig_library",
+    "zig_package",
+    "zig_test",
+)
 
 _SRCS = [
     "src/Directory.zig",
@@ -22,6 +27,21 @@ zig_test(
     srcs = _SRCS,
     cdeps = ["//zig/lib:libc"],
     main = "runfiles.zig",
+)
+
+# Only used for documentation generation.
+zig_library(
+    name = "lib",
+    srcs = _SRCS,
+    main = "runfiles.zig",
+    tags = ["manual"],
+)
+
+filegroup(
+    name = "docs",
+    srcs = [":lib"],
+    output_group = "zig_docs",
+    visibility = ["//visibility:public"],
 )
 
 # Execute `bazel run //util:update_filegroups` to update this target.

--- a/zig/runfiles/BUILD.bazel
+++ b/zig/runfiles/BUILD.bazel
@@ -51,6 +51,7 @@ filegroup(
     name = "all_files",
     srcs = [
         ":BUILD.bazel",
+        ":guide.md",
         ":runfiles.zig",
         ":src/Directory.zig",
         ":src/Manifest.zig",
@@ -58,6 +59,7 @@ filegroup(
         ":src/RepoMapping.zig",
         ":src/Runfiles.zig",
         ":src/discovery.zig",
+        ":test-data.txt",
     ],
     visibility = ["//zig:__pkg__"],
 )

--- a/zig/runfiles/BUILD.bazel
+++ b/zig/runfiles/BUILD.bazel
@@ -26,6 +26,7 @@ zig_test(
     size = "small",
     srcs = _SRCS,
     cdeps = ["//zig/lib:libc"],
+    data = ["test-data.txt"],
     main = "runfiles.zig",
 )
 

--- a/zig/runfiles/BUILD.bazel
+++ b/zig/runfiles/BUILD.bazel
@@ -34,6 +34,7 @@ zig_test(
 zig_library(
     name = "lib",
     srcs = _SRCS,
+    extra_docs = ["guide.md"],
     main = "runfiles.zig",
     tags = ["manual"],
 )

--- a/zig/runfiles/guide.md
+++ b/zig/runfiles/guide.md
@@ -1,0 +1,76 @@
+# Zig Runfiles Guide
+
+This module provides a runfiles library for the Zig programming language: A
+unified interface to discover run-time dependencies of Zig targets built by
+Bazel.
+
+Bazel manages build-time and run-time dependencies. Run-time dependencies are
+typically expressed using the `data` attribute of a rule, but may come about in
+other ways as well. A Bazel produced executable can be executed in a variety of
+ways. For example, using the `bazel run` or `bazel test` commands, as a build
+tool during the build of another target, or directly as a just built or
+deployed artifact.
+
+Run-time dependencies must be provided in a location where the executable can
+discover them for all these different modes of execution and on all supported
+platforms. To that end Bazel defines the [runfiles mechanism][bazel-runfiles].
+
+The details are quite involved. To avoid error-prone repetition of the runfiles
+discovery logic across components and projects, Bazel defines the [runfiles
+library interface][runfiles-library] ([revised for bzlmod][runfiles-bzlmod]): A
+dedicated library for each supported programming language to abstract over the
+runfiles discovery mechanism.
+
+[bazel-runfiles]: https://bazel.build/extending/rules#runfiles
+[runfiles-library]: https://docs.google.com/document/d/e/2PACX-1vSDIrFnFvEYhKsCMdGdD40wZRBX3m3aZ5HhVj4CtHPmiXKDCxioTUbYsDydjKtFDAzER5eg7OjJWs3V/pub
+[runfiles-bzlmod]: https://github.com/bazelbuild/proposals/blob/53c5691c3f08011f0abf1d840d5824a3bbe039e2/designs/2022-07-21-locating-runfiles-with-bzlmod.md
+
+## Documentation
+
+Execute the following commands to build a rendered version of the `rules_zig`
+runfiles user-guide and API documentation:
+
+```console
+$ bazel build @rules_zig//zig/runfiles:docs
+...
+Target @@rules_zig~//zig/runfiles:docs up-to-date:
+  bazel-bin/external/rules_zig~/zig/runfiles/lib.docs
+```
+
+Then open the generated documentation with your browser:
+
+```console
+$ xdg-open bazel-bin/external/rules_zig~/zig/runfiles/lib.docs/index.html
+```
+
+Be sure to use the correct build output path as reported by Bazel. It may vary
+between versions and from machine to machine.
+
+## Usage
+
+Follow the steps below to use this runfiles library in a Zig target.
+
+1. Depend on this runfiles module from your build rule:
+
+   ```bzl
+   zig_binary(
+       name = "my_binary",
+       ...
+       deps = ["@rules_zig//zig/runfiles"],
+   )
+   ```
+
+2. Import the `runfiles` module:
+
+   ```zig
+   const runfiles = @import("runfiles");
+   ```
+
+3. Create a `runfiles.Runfiles` object using `runfiles.Runfiles.create`.
+
+   See `runfiles.Runfiles` doctest for a worked example.
+
+4. Use `runfiles.Runfiles.rlocation` or `runfiles.Runfiles.rlocationAlloc`
+   to look up a runfile path.
+
+   See `runfiles.Runfiles` doctest for a worked example.

--- a/zig/runfiles/runfiles.zig
+++ b/zig/runfiles/runfiles.zig
@@ -23,7 +23,8 @@ test {
 test Runfiles {
     var allocator = std.testing.allocator;
 
-    var r = try Runfiles.create(.{ .allocator = allocator });
+    var r = try Runfiles.create(.{ .allocator = allocator }) orelse
+        return error.RunfilesNotFound;
     defer r.deinit(allocator);
 
     // Runfiles paths have the form `WORKSPACE/PACKAGE/FILE`.

--- a/zig/runfiles/runfiles.zig
+++ b/zig/runfiles/runfiles.zig
@@ -5,6 +5,8 @@
 //! [runfiles-design]: https://docs.google.com/document/d/e/2PACX-1vSDIrFnFvEYhKsCMdGdD40wZRBX3m3aZ5HhVj4CtHPmiXKDCxioTUbYsDydjKtFDAzER5eg7OjJWs3V/pub
 //! [runfiles-bzlmod]: https://github.com/bazelbuild/proposals/blob/53c5691c3f08011f0abf1d840d5824a3bbe039e2/designs/2022-07-21-locating-runfiles-with-bzlmod.md#2-extend-the-runfiles-libraries-to-take-repository-mappings-into-account
 //!
+//! Read the [Zig Runfiles Guide](#G;) for further information.
+//!
 //!zig-autodoc-guide: guide.md
 
 const std = @import("std");

--- a/zig/runfiles/runfiles.zig
+++ b/zig/runfiles/runfiles.zig
@@ -5,6 +5,8 @@
 //! [runfiles-design]: https://docs.google.com/document/d/e/2PACX-1vSDIrFnFvEYhKsCMdGdD40wZRBX3m3aZ5HhVj4CtHPmiXKDCxioTUbYsDydjKtFDAzER5eg7OjJWs3V/pub
 //! [runfiles-bzlmod]: https://github.com/bazelbuild/proposals/blob/53c5691c3f08011f0abf1d840d5824a3bbe039e2/designs/2022-07-21-locating-runfiles-with-bzlmod.md#2-extend-the-runfiles-libraries-to-take-repository-mappings-into-account
 
+const std = @import("std");
+
 pub const Runfiles = @import("src/Runfiles.zig");
 
 test {
@@ -14,4 +16,40 @@ test {
     _ = @import("src/RepoMapping.zig");
     _ = @import("src/RPath.zig");
     _ = @import("src/Runfiles.zig");
+}
+
+test Runfiles {
+    var allocator = std.testing.allocator;
+
+    var r = try Runfiles.create(.{ .allocator = allocator });
+    defer r.deinit(allocator);
+
+    // Runfiles paths have the form `WORKSPACE/PACKAGE/FILE`.
+    // Use `$(rlocationpath ...)` expansion in your `BUILD.bazel` file to
+    // obtain one. You can forward it to your executable using the `env` or
+    // `args` attribute, or by embedding it in a generated file.
+    const rpath = "rules_zig/zig/runfiles/test-data.txt";
+    // Runfiles lookup is subject to repository remapping. You must pass the
+    // name of the repository relative to which the runfiles path is valid.
+    // Use the auto-generated `bazel_builtin` module to obtain it.
+    const source = @import("bazel_builtin").current_repository;
+
+    const allocated_path = try r.rlocationAlloc(allocator, rpath, source) orelse
+        // Runfiles path lookup may return `null`.
+        return error.RPathNotFound;
+    defer allocator.free(allocated_path);
+
+    const file = std.fs.openFileAbsolute(allocated_path, .{}) catch |e| switch (e) {
+        error.FileNotFound => {
+            // Runfiles path lookup may return a non-existent path.
+            return error.RPathNotFound;
+        },
+        else => |e_| return e_,
+    };
+    defer file.close();
+
+    const content = try file.readToEndAlloc(allocator, 4096);
+    defer allocator.free(content);
+
+    try std.testing.expectEqualStrings("Hello World!\n", content);
 }

--- a/zig/runfiles/runfiles.zig
+++ b/zig/runfiles/runfiles.zig
@@ -4,6 +4,8 @@
 //!
 //! [runfiles-design]: https://docs.google.com/document/d/e/2PACX-1vSDIrFnFvEYhKsCMdGdD40wZRBX3m3aZ5HhVj4CtHPmiXKDCxioTUbYsDydjKtFDAzER5eg7OjJWs3V/pub
 //! [runfiles-bzlmod]: https://github.com/bazelbuild/proposals/blob/53c5691c3f08011f0abf1d840d5824a3bbe039e2/designs/2022-07-21-locating-runfiles-with-bzlmod.md#2-extend-the-runfiles-libraries-to-take-repository-mappings-into-account
+//!
+//!zig-autodoc-guide: guide.md
 
 const std = @import("std");
 

--- a/zig/runfiles/src/Runfiles.zig
+++ b/zig/runfiles/src/Runfiles.zig
@@ -10,8 +10,6 @@ const RPath = @import("RPath.zig");
 
 const Runfiles = @This();
 
-pub const repo_mapping_file_name = "_repo_mapping";
-
 implementation: Implementation,
 repo_mapping: ?RepoMapping,
 
@@ -243,7 +241,7 @@ const Implementation = union(discovery.Strategy) {
 
         const path = try self.rlocationUnmappedAlloc(allocator, .{
             .repo = "",
-            .path = repo_mapping_file_name,
+            .path = discovery.repo_mapping_file_name,
         }) orelse {
             log.warn(msg_not_found, .{});
             return null;

--- a/zig/runfiles/src/discovery.zig
+++ b/zig/runfiles/src/discovery.zig
@@ -9,6 +9,7 @@ pub const runfiles_manifest_var_name = "RUNFILES_MANIFEST_FILE";
 pub const runfiles_directory_var_name = "RUNFILES_DIR";
 pub const runfiles_manifest_suffix = ".runfiles_manifest";
 pub const runfiles_directory_suffix = ".runfiles";
+pub const repo_mapping_file_name = "_repo_mapping";
 
 /// * Manifest-based: reads the runfiles manifest file to look up runfiles.
 /// * Directory-based: appends the runfile's path to the runfiles root.

--- a/zig/runfiles/src/discovery.zig
+++ b/zig/runfiles/src/discovery.zig
@@ -32,7 +32,7 @@ pub const Location = union(Strategy) {
 };
 
 pub const DiscoverOptions = struct {
-    /// Used to allocate intermediate data and the final location.
+    /// Used during runfiles discovery.
     allocator: std.mem.Allocator,
     /// User override for the `RUNFILES_MANIFEST_FILE` variable.
     manifest: ?[]const u8 = null,

--- a/zig/runfiles/test-data.txt
+++ b/zig/runfiles/test-data.txt
@@ -1,0 +1,1 @@
+Hello World!

--- a/zig/tests/integration_tests/workspace/runfiles/main.zig
+++ b/zig/tests/integration_tests/workspace/runfiles/main.zig
@@ -8,7 +8,8 @@ pub fn main() !void {
 
     const allocator = arena.allocator();
 
-    var r = try runfiles.Runfiles.create(.{ .allocator = allocator });
+    var r = try runfiles.Runfiles.create(.{ .allocator = allocator }) orelse
+        return error.RunfilesNotFound;
     defer r.deinit(allocator);
 
     const rpath = "__main__/runfiles/data.txt";


### PR DESCRIPTION
Part of #86

- Generate Zig docs for the runfiles library
- Add doctest for runfiles library
- Add a autodoc guide to the runfiles library
- Expand runfiles API docs
- Runfiles.create return optional
- Move runfiles path constants into discovery
- Link to the guide from the API docs
- Link to runfiles docs from README
- Test runfiles docs build in e2e test
- fix comment
