### PR TITLE
feat: introduce Runfiles.withSourceRepo

### DIFF
--- a/e2e/workspace/runfiles-library/dependency/main.zig
+++ b/e2e/workspace/runfiles-library/dependency/main.zig
@@ -3,13 +3,15 @@ const runfiles = @import("runfiles");
 const bazel_builtin = @import("bazel_builtin");
 
 pub fn readData(allocator: std.mem.Allocator) ![]const u8 {
-    var r = try runfiles.Runfiles.create(.{ .allocator = allocator }) orelse
+    var r_ = try runfiles.Runfiles.create(.{ .allocator = allocator }) orelse
         return error.RunfilesNotFound;
-    defer r.deinit(allocator);
+    defer r_.deinit(allocator);
+
+    const r = r_.withSourceRepo(bazel_builtin.current_repository);
 
     const rpath = "runfiles_library_transitive_dependency/data.txt";
 
-    const file_path = try r.rlocationAlloc(allocator, rpath, bazel_builtin.current_repository) orelse
+    const file_path = try r.rlocationAlloc(allocator, rpath) orelse
         return error.RLocationNotFound;
     defer allocator.free(file_path);
 

--- a/e2e/workspace/runfiles-library/main.zig
+++ b/e2e/workspace/runfiles-library/main.zig
@@ -21,7 +21,10 @@ pub fn main() !void {
     const rpath = try getEnvVar(allocator, "DATA") orelse return error.EnvVarNotFoundDATA;
     defer allocator.free(rpath);
 
-    const file_path = try r.rlocationAlloc(allocator, rpath, "") orelse return error.RLocationNotFound;
+    const file_path = try r
+        .withSourceRepo("")
+        .rlocationAlloc(allocator, rpath) orelse
+        return error.RLocationNotFound;
     defer allocator.free(file_path);
 
     var file = try std.fs.cwd().openFile(file_path, .{});
@@ -41,7 +44,10 @@ test "read data file" {
     const rpath = try getEnvVar(std.testing.allocator, "DATA") orelse return error.EnvVarNotFoundDATA;
     defer std.testing.allocator.free(rpath);
 
-    const file_path = try r.rlocationAlloc(std.testing.allocator, rpath, "") orelse return error.RLocationNotFound;
+    const file_path = try r
+        .withSourceRepo("")
+        .rlocationAlloc(std.testing.allocator, rpath) orelse
+        return error.RLocationNotFound;
     defer std.testing.allocator.free(file_path);
 
     var file = try std.fs.cwd().openFile(file_path, .{});
@@ -61,7 +67,10 @@ test "resolve external dependency rpath" {
     const rpath = try getEnvVar(std.testing.allocator, "DEPENDENCY_DATA") orelse return error.EnvVarNotFoundDEPENDENCY_DATA;
     defer std.testing.allocator.free(rpath);
 
-    const file_path = try r.rlocationAlloc(std.testing.allocator, rpath, "") orelse return error.RLocationNotFound;
+    const file_path = try r
+        .withSourceRepo("")
+        .rlocationAlloc(std.testing.allocator, rpath) orelse
+        return error.RLocationNotFound;
     defer std.testing.allocator.free(file_path);
 
     var file = try std.fs.cwd().openFile(file_path, .{});
@@ -88,7 +97,10 @@ test "runfiles in nested binary" {
     const rpath = try getEnvVar(std.testing.allocator, "BINARY") orelse return error.EnvVarNotFoundBINARY;
     defer std.testing.allocator.free(rpath);
 
-    const binary_path = try r.rlocationAlloc(std.testing.allocator, rpath, "") orelse return error.RLocationNotFound;
+    const binary_path = try r
+        .withSourceRepo("")
+        .rlocationAlloc(std.testing.allocator, rpath) orelse
+        return error.RLocationNotFound;
     defer std.testing.allocator.free(binary_path);
 
     var env = std.process.EnvMap.init(std.testing.allocator);

--- a/zig/runfiles/guide.md
+++ b/zig/runfiles/guide.md
@@ -68,9 +68,9 @@ Follow the steps below to use this runfiles library in a Zig target.
 
 3. Create a `runfiles.Runfiles` object using `runfiles.Runfiles.create`.
 
-   See `runfiles.Runfiles` doctest for a worked example.
+4. Define the source repository using `runfiles.Runfiles.withSourceRepo`.
 
-4. Use `runfiles.Runfiles.rlocation` or `runfiles.Runfiles.rlocationAlloc`
-   to look up a runfile path.
+5. Use `runfiles.Runfiles.WithSourceRepo.rlocation` or
+   `runfiles.Runfiles.WithSourceRepo.rlocationAlloc` to look up a runfile path.
 
    See `runfiles.Runfiles` doctest for a worked example.

--- a/zig/runfiles/src/Runfiles.zig
+++ b/zig/runfiles/src/Runfiles.zig
@@ -94,7 +94,7 @@ pub const RLocationError = error{
 /// `BUILD.bazel` file to obtain a runfiles path.
 ///
 /// The runfiles path is subject to repository mapping and will be resolved
-/// relative to the given `source` repository name.
+/// relative to the given source repository name `source_repo`.
 /// Use the automatically generated `bazel_builtin` module to obtain the
 /// current repository name.
 ///
@@ -114,11 +114,11 @@ pub const RLocationError = error{
 pub fn rlocation(
     self: *const Runfiles,
     rpath: []const u8,
-    source: []const u8,
+    source_repo: []const u8,
     out_buffer: []u8,
 ) RLocationError!?[]const u8 {
     try validateRPath(rpath);
-    const rpath_ = self.remapRPath(rpath, source);
+    const rpath_ = self.remapRPath(rpath, source_repo);
     return try self.implementation.rlocationUnmapped(rpath_, out_buffer);
 }
 
@@ -128,10 +128,10 @@ pub fn rlocationAlloc(
     self: *const Runfiles,
     allocator: std.mem.Allocator,
     rpath: []const u8,
-    source: []const u8,
+    source_repo: []const u8,
 ) (error{OutOfMemory} || RLocationError)!?[]const u8 {
     try validateRPath(rpath);
-    const rpath_ = self.remapRPath(rpath, source);
+    const rpath_ = self.remapRPath(rpath, source_repo);
     return try self.implementation.rlocationUnmappedAlloc(allocator, rpath_);
 }
 

--- a/zig/tests/integration_tests/workspace/runfiles/main.zig
+++ b/zig/tests/integration_tests/workspace/runfiles/main.zig
@@ -8,13 +8,15 @@ pub fn main() !void {
 
     const allocator = arena.allocator();
 
-    var r = try runfiles.Runfiles.create(.{ .allocator = allocator }) orelse
+    var r_ = try runfiles.Runfiles.create(.{ .allocator = allocator }) orelse
         return error.RunfilesNotFound;
-    defer r.deinit(allocator);
+    defer r_.deinit(allocator);
+
+    const r = r_.withSourceRepo(bazel_builtin.current_repository);
 
     const rpath = "__main__/runfiles/data.txt";
 
-    const file_path = try r.rlocationAlloc(allocator, rpath, bazel_builtin.current_repository) orelse {
+    const file_path = try r.rlocationAlloc(allocator, rpath) orelse {
         std.log.err("Runfiles location '{s}' not found", .{rpath});
         return error.RLocationNotFound;
     };


### PR DESCRIPTION
Closes #86

With `Runfiles.withSourceRepo` users can specify the source repository name once and then perform multiple runfile path lookups relative to the same source repository.

- source --> source_repo
- introduce `withSourceRepo` function
