### PR TITLE
chore: refactor ZigModuleInfo

### DIFF
--- a/zig/private/common/bazel_builtin.bzl
+++ b/zig/private/common/bazel_builtin.bzl
@@ -1,6 +1,9 @@
 """Generate the `bazel_builtin` module."""
 
-load("//zig/private/providers:zig_module_info.bzl", "ZigModuleInfo")
+load(
+    "//zig/private/providers:zig_module_info.bzl",
+    "zig_module_info",
+)
 
 ATTRS = {
     "_bazel_builtin_template": attr.label(
@@ -41,16 +44,13 @@ def bazel_builtin_module(ctx):
         is_executable = False,
     )
 
-    module = ZigModuleInfo(
+    module = zig_module_info(
         name = "bazel_builtin",
         canonical_name = name,
         main = main,
         srcs = [],
-        all_mods = depset(direct = ["{name}::{src}".format(
-            name = name,
-            src = main.path,
-        )]),
-        all_srcs = depset(direct = [main]),
+        extra_srcs = [],
+        deps = [],
     )
 
     return module

--- a/zig/private/providers/zig_module_info.bzl
+++ b/zig/private/providers/zig_module_info.bzl
@@ -13,8 +13,6 @@ instead the Zig compiler performs whole program compilation.
 FIELDS = {
     "name": "string, The import name of the module.",
     "canonical_name": "string, The canonical name may differ from the import name via remapping.",
-    "main": "File, The main source file of the module.",
-    "srcs": "list of File, Other Zig source files that belong to the module.",
     "all_mods": "depset of string, All module CLI specifications required when depending on the module.",
     "all_srcs": "depset of File, All source files required when depending on the module.",
 }
@@ -61,8 +59,6 @@ def zig_module_info(*, name, canonical_name, main, srcs, extra_srcs, deps):
     module = ZigModuleInfo(
         name = name,
         canonical_name = canonical_name,
-        main = main,
-        srcs = srcs,
         all_mods = all_mods,
         all_srcs = all_srcs,
     )

--- a/zig/tests/module_info_test.bzl
+++ b/zig/tests/module_info_test.bzl
@@ -13,12 +13,25 @@ load(
 def _mock_args():
     self_args = []
 
-    def add_all(args, *, before_each = None):
+    def add_all(args, *, map_each = None):
         if type(args) == "depset":
             args = args.to_list()
+
+        if map_each != None:
+            mapped = []
+
+            for arg in args:
+                result = map_each(arg)
+                if result == None or result == []:
+                    continue
+                if type(result) == "list":
+                    mapped.extend(result)
+                else:
+                    mapped.append(result)
+
+            args = mapped
+
         for arg in args:
-            if before_each:
-                self_args.append(before_each)
             if type(arg) == "File":
                 self_args.append(arg.path)
             else:

--- a/zig/tests/module_info_test.bzl
+++ b/zig/tests/module_info_test.bzl
@@ -107,7 +107,7 @@ def _single_module_test_impl(ctx):
 
     bazel_builtin_file = [
         file
-        for file in module.all_srcs.to_list()
+        for file in module.transitive_inputs.to_list()
         if file.path == _bazel_builtin_file_name(ctx, ctx.attr.mod.label)
     ]
 
@@ -158,7 +158,7 @@ def _nested_modules_test_impl(ctx):
             dep = _bazel_builtin_dep(mod.label),
             file = [
                 file
-                for file in mods[mod.label.name].all_srcs.to_list()
+                for file in mods[mod.label.name].transitive_inputs.to_list()
                 if file.path == _bazel_builtin_file_name(ctx, mod.label)
             ],
         )

--- a/zig/tests/multiple-sources-module/BUILD.bazel
+++ b/zig/tests/multiple-sources-module/BUILD.bazel
@@ -1,5 +1,14 @@
 load("@rules_zig//zig:defs.bzl", "zig_module")
 
+exports_files(
+    [
+        "data.zig",
+        "data/hello.zig",
+        "data/world.zig",
+    ],
+    visibility = ["//zig/tests:__pkg__"],
+)
+
 zig_module(
     name = "data",
     srcs = [

--- a/zig/tests/nested-modules/BUILD.bazel
+++ b/zig/tests/nested-modules/BUILD.bazel
@@ -1,5 +1,17 @@
 load("@rules_zig//zig:defs.bzl", "zig_module")
 
+exports_files(
+    [
+        "a.zig",
+        "b.zig",
+        "c.zig",
+        "d.zig",
+        "e.zig",
+        "f.zig",
+    ],
+    visibility = ["//zig/tests:__pkg__"],
+)
+
 zig_module(
     name = "a",
     main = "a.zig",


### PR DESCRIPTION
Zig's module system is changing drastically between releases. However, the direction seems to be a system where each module is represented on the command-line by a either multiple arguments in a specific order (0.12.0) or a single flag with a complex structure (0.11.0). Neither of those lends itself to tracking parts of the command-line separately in `depset` values to later on pass to `args.add_all`.

Instead, we track modules in a `depset` of `struct` that carries all relevant information for each module, and later apply `args.add_all` using the `map_each` parameter to render the flags for each module.

- **zig_module_info constructor function**
- **Use zig_module_info**
- **Remove unused ZigModuleInfo fields**
- **pkg --> mod in module info test**
- **Store structured module arguments**
- **Factor out dependency name rendering**
- **Change ZigModuleInfo field names**
