### PR TITLE
feat: sort specified Zig SDK versions by semantic version

### DIFF
--- a/zig/BUILD.bazel
+++ b/zig/BUILD.bazel
@@ -78,6 +78,7 @@ bzl_library(
     visibility = ["//visibility:public"],
     deps = [
         ":repositories",
+        "//zig/private/common:semver",
         "@bazel_skylib//lib:sets",
     ],
 )

--- a/zig/extensions.bzl
+++ b/zig/extensions.bzl
@@ -35,7 +35,7 @@ def _toolchain_extension(module_ctx):
 
     zig_register_toolchains(
         name = _DEFAULT_NAME,
-        zig_versions = semver.sorted(sets.to_list(versions)),
+        zig_versions = semver.sorted(sets.to_list(versions), reverse = True),
         register = False,
     )
 

--- a/zig/extensions.bzl
+++ b/zig/extensions.bzl
@@ -1,6 +1,7 @@
 """Extensions for bzlmod."""
 
 load("@bazel_skylib//lib:sets.bzl", "sets")
+load("//zig/private/common:semver.bzl", "semver")
 load(":repositories.bzl", "zig_register_toolchains")
 
 _DOC = """\
@@ -34,7 +35,7 @@ def _toolchain_extension(module_ctx):
 
     zig_register_toolchains(
         name = _DEFAULT_NAME,
-        zig_versions = sets.to_list(versions),
+        zig_versions = semver.sorted(sets.to_list(versions)),
         register = False,
     )
 

--- a/zig/private/common/BUILD.bazel
+++ b/zig/private/common/BUILD.bazel
@@ -101,6 +101,12 @@ bzl_library(
 )
 
 bzl_library(
+    name = "semver",
+    srcs = ["semver.bzl"],
+    visibility = ["//zig:__subpackages__"],
+)
+
+bzl_library(
     name = "zig_target_triple",
     srcs = ["zig_target_triple.bzl"],
     visibility = ["//zig:__subpackages__"],
@@ -119,6 +125,7 @@ filegroup(
         ":filetypes.bzl",
         ":linker_script.bzl",
         ":location_expansion.bzl",
+        ":semver.bzl",
         ":zig_build.bzl",
         ":zig_cache.bzl",
         ":zig_docs.bzl",

--- a/zig/private/common/semver.bzl
+++ b/zig/private/common/semver.bzl
@@ -3,13 +3,36 @@
 See https://semver.org/
 """
 
+def _parse_pre_release_component(component):
+    """Parse a pre-release component for sorting."""
+    num = float("+Infinity")
+    alpha = ""
+    if component.isdigit():
+        num = int(component)
+    else:
+        alpha = component
+
+    return (False, num, alpha)
+
 def _parse(version):
-    """Split a semantic version into its components"""
+    """Split a semantic version into its components for comparison."""
+    if version.find("+") != -1:
+        version, _build = version.split("+", 1)
+
+    pre_release = [(True, 0, "")]
+    if version.find("-") != -1:
+        version, pre_release = version.split("-", 1)
+        pre_release = [
+            _parse_pre_release_component(component)
+            for component in pre_release.split(".")
+        ]
+
     major, minor, patch = version.split(".", 3)
     return struct(
         major = int(major),
         minor = int(minor),
         patch = int(patch),
+        pre_release = pre_release,
     )
 
 def _sorted(versions):
@@ -17,7 +40,7 @@ def _sorted(versions):
 
     def key(version):
         parsed = _parse(version)
-        return [parsed.major, parsed.minor, parsed.patch]
+        return [parsed.major, parsed.minor, parsed.patch, parsed.pre_release]
 
     return sorted(versions, key = key)
 

--- a/zig/private/common/semver.bzl
+++ b/zig/private/common/semver.bzl
@@ -1,0 +1,26 @@
+"""Utility functions to manage semantic versions.
+
+See https://semver.org/
+"""
+
+def _parse(version):
+    """Split a semantic version into its components"""
+    major, minor, patch = version.split(".", 3)
+    return struct(
+        major = int(major),
+        minor = int(minor),
+        patch = int(patch),
+    )
+
+def _sorted(versions):
+    """Sort a list of strings by semantic version comparison."""
+
+    def key(version):
+        parsed = _parse(version)
+        return [parsed.major, parsed.minor, parsed.patch]
+
+    return sorted(versions, key = key)
+
+semver = struct(
+    sorted = _sorted,
+)

--- a/zig/private/common/semver.bzl
+++ b/zig/private/common/semver.bzl
@@ -35,14 +35,14 @@ def _parse(version):
         pre_release = pre_release,
     )
 
-def _sorted(versions):
+def _sorted(versions, *, reverse = False):
     """Sort a list of strings by semantic version comparison."""
 
     def key(version):
         parsed = _parse(version)
         return [parsed.major, parsed.minor, parsed.patch, parsed.pre_release]
 
-    return sorted(versions, key = key)
+    return sorted(versions, key = key, reverse = reverse)
 
 semver = struct(
     sorted = _sorted,

--- a/zig/tests/BUILD.bazel
+++ b/zig/tests/BUILD.bazel
@@ -4,6 +4,7 @@ load(":config_test.bzl", "config_test_suite")
 load(":mode_test.bzl", "mode_test_suite")
 load(":module_info_test.bzl", "module_info_test_suite")
 load(":rules_test.bzl", "rules_test_suite")
+load(":semver_test.bzl", "semver_test_suite")
 load(":target_platform_test.bzl", "target_platform_test_suite")
 load(":target_triple_test.bzl", "target_triple_test_suite")
 load(":threaded_test.bzl", "threaded_test_suite")
@@ -18,6 +19,8 @@ mode_test_suite(name = "mode_test")
 module_info_test_suite(name = "module_info_test")
 
 rules_test_suite(name = "rules_test")
+
+semver_test_suite(name = "semver_test")
 
 target_platform_test_suite(name = "target_platform_test")
 

--- a/zig/tests/semver_test.bzl
+++ b/zig/tests/semver_test.bzl
@@ -1,0 +1,17 @@
+"""Unit tests for semantic version helpers."""
+
+load("@bazel_skylib//lib:partial.bzl", "partial")
+load("@bazel_skylib//lib:unittest.bzl", "unittest")
+
+def _sorted_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    return unittest.end(env)
+
+_sorted_test = unittest.make(_sorted_test_impl)
+
+def semver_test_suite(name):
+    unittest.suite(
+        name,
+        partial.make(_sorted_test, size = "small"),
+    )

--- a/zig/tests/semver_test.bzl
+++ b/zig/tests/semver_test.bzl
@@ -1,10 +1,23 @@
 """Unit tests for semantic version helpers."""
 
 load("@bazel_skylib//lib:partial.bzl", "partial")
-load("@bazel_skylib//lib:unittest.bzl", "unittest")
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//zig/private/common:semver.bzl", "semver")
 
 def _sorted_test_impl(ctx):
     env = unittest.begin(ctx)
+
+    asserts.equals(
+        env,
+        ["1.0.0", "2.0.0", "10.0.0"],
+        semver.sorted(["2.0.0", "10.0.0", "1.0.0"]),
+    )
+
+    asserts.equals(
+        env,
+        ["1.0.0", "2.0.0", "2.1.0", "2.1.1"],
+        semver.sorted(["2.1.1", "2.0.0", "2.1.0", "1.0.0"]),
+    )
 
     return unittest.end(env)
 

--- a/zig/tests/semver_test.bzl
+++ b/zig/tests/semver_test.bzl
@@ -19,6 +19,36 @@ def _sorted_test_impl(ctx):
         semver.sorted(["2.1.1", "2.0.0", "2.1.0", "1.0.0"]),
     )
 
+    asserts.equals(
+        env,
+        ["1.0.0-alpha", "1.0.0"],
+        semver.sorted(["1.0.0", "1.0.0-alpha"]),
+    )
+
+    asserts.equals(
+        env,
+        ["1.0.0-0", "1.0.0-1", "1.0.0-alpha"],
+        semver.sorted(["1.0.0-1", "1.0.0-alpha", "1.0.0-0"]),
+    )
+
+    asserts.equals(
+        env,
+        ["1.0.0-1.2", "1.0.0-1.2.3"],
+        semver.sorted(["1.0.0-1.2.3", "1.0.0-1.2"]),
+    )
+
+    asserts.equals(
+        env,
+        ["1.0.0-alpha", "1.0.0-alpha.1", "1.0.0-alpha.beta", "1.0.0-beta", "1.0.0-beta.2", "1.0.0-beta.11", "1.0.0-rc.1", "1.0.0"],
+        semver.sorted(["1.0.0", "1.0.0-rc.1", "1.0.0-beta.11", "1.0.0-alpha.beta", "1.0.0-beta", "1.0.0-alpha", "1.0.0-alpha.1", "1.0.0-beta.2"]),
+    )
+
+    asserts.equals(
+        env,
+        ["1.0.0+5", "1.0.1", "1.0.2+4"],
+        semver.sorted(["1.0.2+4", "1.0.1", "1.0.0+5"]),
+    )
+
     return unittest.end(env)
 
 _sorted_test = unittest.make(_sorted_test_impl)

--- a/zig/tests/semver_test.bzl
+++ b/zig/tests/semver_test.bzl
@@ -21,6 +21,12 @@ def _sorted_test_impl(ctx):
 
     asserts.equals(
         env,
+        ["2.1.1", "2.1.0", "2.0.0", "1.0.0"],
+        semver.sorted(["2.1.1", "2.0.0", "2.1.0", "1.0.0"], reverse = True),
+    )
+
+    asserts.equals(
+        env,
         ["1.0.0-alpha", "1.0.0"],
         semver.sorted(["1.0.0", "1.0.0-alpha"]),
     )


### PR DESCRIPTION
Part of #257

- **Add unit test suite for semver module**
- **Parse main components**
- **Handle pre-release and build components**
- **feat: support reversed semver sort**
- **test: reversed semver sort**
- **fix zig version sort**
- **update generated files**
