### PR TITLE
feat: implicit default Zig SDK version

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,7 +9,6 @@ bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(name = "platforms", version = "0.0.9")
 
 zig = use_extension("//zig:extensions.bzl", "zig")
-zig.toolchain(zig_version = "0.11.0")
 use_repo(zig, "zig_toolchains")
 
 register_toolchains("@rules_zig//zig/target:all")

--- a/zig/extensions.bzl
+++ b/zig/extensions.bzl
@@ -1,6 +1,7 @@
 """Extensions for bzlmod."""
 
 load("@bazel_skylib//lib:sets.bzl", "sets")
+load("//zig/private:versions.bzl", "TOOL_VERSIONS")
 load("//zig/private/common:semver.bzl", "semver")
 load(":repositories.bzl", "zig_register_toolchains")
 
@@ -18,6 +19,7 @@ due to toolchain resolution precedence.
 """
 
 _DEFAULT_NAME = "zig"
+_DEFAULT_VERSION = TOOL_VERSIONS.keys()[0]
 
 zig_toolchain = tag_class(attrs = {
     "zig_version": attr.string(doc = "Explicit version of Zig.", mandatory = True),
@@ -33,9 +35,13 @@ def _toolchain_extension(module_ctx):
         for toolchain in mod.tags.toolchain:
             sets.insert(versions, toolchain.zig_version)
 
+    versions = sets.to_list(versions)
+    if len(versions) == 0:
+        versions.append(_DEFAULT_VERSION)
+
     zig_register_toolchains(
         name = _DEFAULT_NAME,
-        zig_versions = semver.sorted(sets.to_list(versions), reverse = True),
+        zig_versions = semver.sorted(versions, reverse = True),
         register = False,
     )
 


### PR DESCRIPTION
Part of #257

Since rules_zig now supports multiple Zig SDK versions and orders them by semantic versions precedence, the core module (`@rules_zig`) should not always explicitly set a Zig SDK version, as that would prevent any root module from specifying a lower version as the default version.

Instead, the `zig` module extension implicitly sets a default version if none is specified by any module.

- **No Zig version in core module**
- **feat: implicit default Zig SDK version**
