### PR TITLE
chore: trigger CI on base branch change

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, reopened, synchronize, edited]
 
   # Allows you to call this workflow from another workflow
   workflow_call:


### PR DESCRIPTION
As documented in https://github.com/actions/runner/issues/980#issuecomment-777057271

This occurs when a PR is marked as depending on another PR, has that other PR's branch as its base branch, and GitHub then automatically changes the base branch after the first PR is merged.
