### PR TITLE
fix: dynamic linking on MacOS with Zig 0.12.0

### DIFF
--- a/e2e/workspace/link-dependencies/shared-library/BUILD.bazel
+++ b/e2e/workspace/link-dependencies/shared-library/BUILD.bazel
@@ -1,15 +1,6 @@
-load("@bazel_skylib//lib:selects.bzl", "selects")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
 load("@rules_zig//zig:defs.bzl", "zig_binary", "zig_library", "zig_test")
-
-selects.config_setting_group(
-    name = "macos-zig-0.12.0",
-    match_all = [
-        "@platforms//os:macos",
-        "@zig_toolchains//:0.12.0",
-    ],
-)
 
 cc_binary(
     name = "add",
@@ -43,10 +34,6 @@ zig_library(
         "@rules_zig//zig/lib:libc",
     ],
     main = "main.zig",
-    target_compatible_with = select({
-        ":macos-zig-0.12.0": ["@platforms//:incompatible"],
-        "//conditions:default": [],
-    }),
 )
 
 zig_test(
@@ -60,25 +47,11 @@ zig_test(
 )
 
 build_test(
-    name = "build-binary",
+    name = "build",
     size = "small",
     targets = [
         ":binary",
-    ],
-)
-
-build_test(
-    name = "build-library",
-    size = "small",
-    targets = [
         ":library",
-    ],
-)
-
-build_test(
-    name = "build-test",
-    size = "small",
-    targets = [
         ":test",
     ],
 )

--- a/zig/private/common/cdeps.bzl
+++ b/zig/private/common/cdeps.bzl
@@ -90,7 +90,13 @@ def _linking_context(*, linking_context, output_dir, os, inputs, args, data):
                     args.add(file)
 
     data.extend(dynamic_libraries)
-    args.add_all(dynamic_libraries, map_each = _make_to_rpath(output_dir, os), allow_closure = True, before_each = "-rpath")
+    args.add_all(
+        dynamic_libraries,
+        map_each = _make_to_rpath(output_dir, os),
+        allow_closure = True,
+        before_each = "-rpath",
+        uniquify = True,
+    )
 
 def _make_to_rpath(output_dir, os):
     origin = "$ORIGIN"

--- a/zig/private/common/cdeps.bzl
+++ b/zig/private/common/cdeps.bzl
@@ -79,7 +79,15 @@ def _linking_context(*, linking_context, output_dir, os, inputs, args, data):
 
             if file:
                 inputs.append(file)
-                args.add(file)
+                if dynamic:
+                    ext_skip = len(file.extension) + 1
+                    if file.basename.startswith("lib"):
+                        libname = file.basename[3:-ext_skip]
+                    else:
+                        libname = file.basename[:-ext_skip]
+                    args.add_all(["-L" + file.dirname, "-l" + libname])
+                else:
+                    args.add(file)
 
     data.extend(dynamic_libraries)
     args.add_all(dynamic_libraries, map_each = _make_to_rpath(output_dir, os), allow_closure = True, before_each = "-rpath")

--- a/zig/private/common/cdeps.bzl
+++ b/zig/private/common/cdeps.bzl
@@ -47,6 +47,7 @@ def _compilation_context(*, compilation_context, inputs, args):
     args.add_all(compilation_context.framework_includes, format_each = "-F%s")
 
 def _linking_context(*, linking_context, output_dir, os, inputs, args, data):
+    all_libraries = []
     dynamic_libraries = []
     for link in linking_context.linker_inputs.to_list():
         args.add_all(link.user_link_flags)
@@ -65,6 +66,8 @@ def _linking_context(*, linking_context, output_dir, os, inputs, args, data):
                 file = lib.dynamic_library
                 dynamic = True
 
+            all_libraries.append((file, dynamic))
+
             if dynamic and lib.dynamic_library:
                 dynamic_libraries.append(lib.dynamic_library)
 
@@ -79,16 +82,12 @@ def _linking_context(*, linking_context, output_dir, os, inputs, args, data):
 
             if file:
                 inputs.append(file)
-                if dynamic:
-                    ext_skip = len(file.extension) + 1
-                    if file.basename.startswith("lib"):
-                        libname = file.basename[3:-ext_skip]
-                    else:
-                        libname = file.basename[:-ext_skip]
-                    args.add_all(["-L" + file.dirname, "-l" + libname])
-                else:
-                    args.add(file)
 
+    args.add_all(
+        all_libraries,
+        map_each = _lib_flags,
+        uniquify = True,
+    )
     data.extend(dynamic_libraries)
     args.add_all(
         dynamic_libraries,
@@ -97,6 +96,18 @@ def _linking_context(*, linking_context, output_dir, os, inputs, args, data):
         before_each = "-rpath",
         uniquify = True,
     )
+
+def _lib_flags(arg):
+    (file, dynamic) = arg
+    if dynamic:
+        ext_skip = len(file.extension) + 1
+        if file.basename.startswith("lib"):
+            libname = file.basename[3:-ext_skip]
+        else:
+            libname = file.basename[:-ext_skip]
+        return ["-L" + file.dirname, "-l" + libname]
+    else:
+        return file.path
 
 def _make_to_rpath(output_dir, os):
     origin = "$ORIGIN"


### PR DESCRIPTION
Closes #274

Changes the command line to link a dynamic library from `some/libfoo.dylib` to `-Lsome -lfoo`.

- **Revert "skip dylib linking on MacOS with 0.12.0"**
- **Expand dynamic libraries to -L / -l flags**
- **uniquify rpath arguments**
- **Deduplicate library search path flags**
