### PR TITLE
test: re-enable Zig docs generation for Zig 0.12.0 on MaCOS

### DIFF
--- a/zig/runfiles/BUILD.bazel
+++ b/zig/runfiles/BUILD.bazel
@@ -1,17 +1,8 @@
-load("@bazel_skylib//lib:selects.bzl", "selects")
 load(
     "@rules_zig//zig:defs.bzl",
     "zig_library",
     "zig_module",
     "zig_test",
-)
-
-selects.config_setting_group(
-    name = "macos-zig-0.12.0",
-    match_all = [
-        "@platforms//os:macos",
-        "@zig_toolchains//:0.12.0",
-    ],
 )
 
 _SRCS = [
@@ -52,10 +43,6 @@ filegroup(
     name = "docs",
     srcs = [":lib"],
     output_group = "zig_docs",
-    target_compatible_with = select({
-        ":macos-zig-0.12.0": ["@platforms//:incompatible"],
-        "//conditions:default": [],
-    }),
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
Closes #273

This reverts commit fddc80dc8f5e184bb8ad6b5b8758ad3bef55d043.

I am no longer able to reproduce the issue. It is unclear what caused it. It may be worthwhile to inspect items cached in the remote cache for whether they carry references to the global or local Zig cache directory and if any of these pathnames are non-reproducible.
