### PR TITLE
refactor: Track Zig versions in JSON file

### DIFF
--- a/.github/workflows/zig_update.yaml
+++ b/.github/workflows/zig_update.yaml
@@ -18,14 +18,14 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          OLD_VERSION="$(grep -m 1 -oP '^\s+"\K\d+\.\d+\.\d+(?=":)' zig/private/versions.bzl)"
+          OLD_VERSION="$(grep -m 1 -oP '^\s+"\K\d+\.\d+\.\d+(?=":)' zig/private/versions.json)"
           bazel run //util:update_zig_versions
-          [ -z "$(git status --porcelain=v1 zig/private/versions.bzl 2>/dev/null)" ] || {
-            NEW_VERSION="$(grep -m 1 -oP '^\s+"\K\d+\.\d+\.\d+(?=":)' zig/private/versions.bzl)"
+          [ -z "$(git status --porcelain=v1 zig/private/versions.json 2>/dev/null)" ] || {
+            NEW_VERSION="$(grep -m 1 -oP '^\s+"\K\d+\.\d+\.\d+(?=":)' zig/private/versions.json)"
             BRANCH="zig-update-$NEW_VERSION"
             git switch -c "$BRANCH"
-            git add zig/private/versions.bzl 
-            readarray -t FILES < <(git grep -l -F "$OLD_VERSION" -- ':(exclude)zig/private/versions.bzl')
+            git add zig/private/versions.json
+            readarray -t FILES < <(git grep -l -F "$OLD_VERSION" -- ':(exclude)zig/private/versions.json')
             sed -i "s/${OLD_VERSION//./\\.}/$NEW_VERSION/g" "${FILES[@]}"
             git add "${FILES[@]}"
             git config user.name "github-actions[bot]"

--- a/.github/workflows/zig_update.yaml
+++ b/.github/workflows/zig_update.yaml
@@ -25,7 +25,7 @@ jobs:
             BRANCH="zig-update-$NEW_VERSION"
             git switch -c "$BRANCH"
             git add zig/private/versions.json
-            readarray -t FILES < <(git grep -l -F "$OLD_VERSION" -- ':(exclude)zig/private/versions.json')
+            readarray -t FILES < <(git grep -l -F "$OLD_VERSION" -- ':(exclude)zig/private/versions.json' ':(exclude)zig/private/versions.bzl')
             sed -i "s/${OLD_VERSION//./\\.}/$NEW_VERSION/g" "${FILES[@]}"
             git add "${FILES[@]}"
             git config user.name "github-actions[bot]"

--- a/util/BUILD.bazel
+++ b/util/BUILD.bazel
@@ -72,6 +72,14 @@ py_binary(
     args = [
         "--output",
         "$(rootpath //zig/private:versions.json)",
+        "--template-bzl",
+        "$(rootpath //zig/private:versions.bzl.tpl)",
+        "--output-bzl",
+        "$(rootpath //zig/private:versions.bzl)",
     ],
-    data = ["//zig/private:versions.json"],
+    data = [
+        "//zig/private:versions.bzl",
+        "//zig/private:versions.bzl.tpl",
+        "//zig/private:versions.json",
+    ],
 )

--- a/util/BUILD.bazel
+++ b/util/BUILD.bazel
@@ -71,7 +71,7 @@ py_binary(
     srcs = ["update_zig_versions.py"],
     args = [
         "--output",
-        "$(rootpath //zig/private:versions.bzl)",
+        "$(rootpath //zig/private:versions.json)",
     ],
-    data = ["//zig/private:versions.bzl"],
+    data = ["//zig/private:versions.json"],
 )

--- a/util/update_zig_versions.py
+++ b/util/update_zig_versions.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import argparse
-import base64
 import json
 import urllib.request
 
@@ -43,26 +42,6 @@ def fetch_zig_versions(url):
         return json.loads(data.decode('utf-8'))
 
 
-def convert_sha256(sha256_hex):
-    return "sha256-" + base64.b64encode(bytes.fromhex(sha256_hex)).decode()
-
-
-_HEADER = '''\
-"""Mirror of Zig release info.
-
-Generated from {url}.
-"""
-'''
-
-
-_PLATFORM = '''\
-        "{platform}": struct(
-            url = "{url}",
-            integrity = "{integrity}",
-        ),\
-'''
-
-
 def _parse_semver(version_str):
     """Split a semantic version into its components.
 
@@ -94,34 +73,27 @@ def _parse_semver(version_str):
     return major, minor, patch, pre_release_segment
 
 
-def generate_bzl_content(url, data, unsupported_versions, supported_platforms):
-    content = [_HEADER.format(url = url)]
-    content.append("TOOL_VERSIONS = {")
+def generate_json_content(data, unsupported_versions, supported_platforms):
+    content = {}
 
     for version, platforms in sorted(data.items(), key=lambda x: _parse_semver(x[0]), reverse=True):
         if version in unsupported_versions or version == "master":
             continue
 
-        content.append('    "{}": {{'.format(version))
-
         for platform, info in sorted(platforms.items()):
             if platform not in supported_platforms or not isinstance(info, dict):
                 continue
-            content.append(_PLATFORM.format(
-                platform = platform,
-                url = info["tarball"],
-                integrity = convert_sha256(info["shasum"])
-            ))
 
-        content.append('    },')
+            content.setdefault(version, {})[platform] = {
+                "tarball": info["tarball"],
+                "shasum": info["shasum"],
+            }
 
-    content.append('}\n')
-
-    return '\n'.join(content)
+    return content
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Generate Starlark file for Zig compiler versions.")
+    parser = argparse.ArgumentParser(description="Generate JSON file for Zig compiler versions.")
     parser.add_argument("--output", type=argparse.FileType('w'), default='-', help="Output file path or '-' for stdout.")
     parser.add_argument("--url", default=_ZIG_INDEX_URL, help="URL to fetch Zig versions JSON")
     parser.add_argument("--unsupported-versions", nargs="*", default=_UNSUPPORTED_VERSIONS, help="List of unsupported Zig versions")
@@ -129,9 +101,9 @@ def main():
     args = parser.parse_args()
 
     zig_data = fetch_zig_versions(args.url)
-    bzl_content = generate_bzl_content(args.url, zig_data, set(args.unsupported_versions), set(args.supported_platforms))
+    json_content = generate_json_content(zig_data, set(args.unsupported_versions), set(args.supported_platforms))
 
-    args.output.write(bzl_content)
+    json.dump(json_content, args.output, indent=4)
 
 
 if __name__ == "__main__":

--- a/util/update_zig_versions.py
+++ b/util/update_zig_versions.py
@@ -111,12 +111,12 @@ def main():
     zig_data = fetch_zig_versions(args.url)
     json_content = generate_json_content(zig_data, set(args.unsupported_versions), set(args.supported_platforms))
 
-    json.dump(json_content, args.output, indent=4)
+    json.dump(json_content, args.output, indent=2)
 
     if args.template_bzl or args.output_bzl:
         bzl = Template(args.template_bzl.read())
         args.output_bzl.write(bzl.substitute({
-            "ZIG_VERSIONS_JSON": json.dumps(json_content, indent=4),
+            "ZIG_VERSIONS_JSON": json.dumps(json_content, indent=2),
         }))
 
 

--- a/util/update_zig_versions.py
+++ b/util/update_zig_versions.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 
-import urllib.request
-import json
-import base64
 import argparse
+import base64
+import json
+import urllib.request
 
 
 _ZIG_INDEX_URL = "https://ziglang.org/download/index.json"

--- a/util/update_zig_versions.py
+++ b/util/update_zig_versions.py
@@ -112,6 +112,7 @@ def main():
     json_content = generate_json_content(zig_data, set(args.unsupported_versions), set(args.supported_platforms))
 
     json.dump(json_content, args.output, indent=2)
+    args.output.write("\n")
 
     if args.template_bzl or args.output_bzl:
         bzl = Template(args.template_bzl.read())

--- a/zig/private/BUILD.bazel
+++ b/zig/private/BUILD.bazel
@@ -140,6 +140,8 @@ filegroup(
         ":resolved_toolchain.bzl",
         ":settings.bzl",
         ":versions.bzl",
+        ":versions.bzl.tpl",
+        ":versions.json",
         ":zig_binary.bzl",
         ":zig_configure.bzl",
         ":zig_library.bzl",

--- a/zig/private/BUILD.bazel
+++ b/zig/private/BUILD.bazel
@@ -1,7 +1,11 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 exports_files(
-    ["versions.json"],
+    [
+        "versions.json",
+        "versions.bzl.tpl",
+        "versions.bzl",
+    ],
     visibility = ["//util:__pkg__"],
 )
 

--- a/zig/private/BUILD.bazel
+++ b/zig/private/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 exports_files(
-    ["versions.bzl"],
+    ["versions.json"],
     visibility = ["//util:__pkg__"],
 )
 

--- a/zig/private/bzlmod/zig.bzl
+++ b/zig/private/bzlmod/zig.bzl
@@ -1,9 +1,11 @@
 """Implementation of the `zig` module extension."""
 
 load("@bazel_skylib//lib:sets.bzl", "sets")
-load("//zig:repositories.bzl", "zig_register_toolchains")
+load("//zig/private:platforms.bzl", "PLATFORMS")
 load("//zig/private:versions.bzl", "TOOL_VERSIONS")
 load("//zig/private/common:semver.bzl", "semver")
+load("//zig/private/repo:toolchains_repo.bzl", "sanitize_version", "toolchains_repo")
+load("//zig/private/repo:zig_repository.bzl", "zig_repository")
 
 DOC = """\
 Installs a Zig toolchain.
@@ -72,16 +74,57 @@ def handle_tags(module_ctx):
 
     return None, versions
 
+def _parse_zig_versions_json(json_string):
+    result = {}
+
+    data = json.decode(json_string)
+    for version, platforms in data.items():
+        for platform, info in platforms.items():
+            result.setdefault(version, {})[platform] = struct(
+                url = info["tarball"],
+                sha256 = info["shasum"],
+            )
+
+    return result
+
 def _toolchain_extension(module_ctx):
+    zig_versions_json_path = module_ctx.path(Label("//zig/private:versions.json"))
+    known_versions = _parse_zig_versions_json(module_ctx.read(zig_versions_json_path))
+
     (err, versions) = handle_tags(module_ctx)
 
     if err != None:
         fail(*err)
 
-    zig_register_toolchains(
-        name = _DEFAULT_NAME,
-        zig_versions = versions,
-        register = False,
+    toolchain_names = []
+    toolchain_labels = []
+    toolchain_zig_versions = []
+    toolchain_exec_lengths = []
+    toolchain_exec_constraints = []
+    for zig_version in versions:
+        sanitized_zig_version = sanitize_version(zig_version)
+        for platform, meta in PLATFORMS.items():
+            repo_name = _DEFAULT_NAME + "_" + sanitized_zig_version + "_" + platform
+            toolchain_names.append(repo_name)
+            toolchain_labels.append("@{}//:zig_toolchain".format(repo_name))
+            toolchain_zig_versions.append(zig_version)
+            toolchain_exec_lengths.append(len(meta.compatible_with))
+            toolchain_exec_constraints.extend(meta.compatible_with)
+            zig_repository(
+                name = repo_name,
+                url = known_versions[zig_version][platform].url,
+                sha256 = known_versions[zig_version][platform].sha256,
+                zig_version = zig_version,
+                platform = platform,
+            )
+
+    toolchains_repo(
+        name = _DEFAULT_NAME + "_toolchains",
+        names = toolchain_names,
+        labels = toolchain_labels,
+        zig_versions = toolchain_zig_versions,
+        exec_lengths = toolchain_exec_lengths,
+        exec_constraints = toolchain_exec_constraints,
     )
 
 zig = module_extension(

--- a/zig/private/versions.bzl
+++ b/zig/private/versions.bzl
@@ -3,73 +3,87 @@
 Generated from https://ziglang.org/download/index.json.
 """
 
-TOOL_VERSIONS = {
+def _parse(json_string):
+    data = json.decode(json_string)
+    result = {}
+    for version, platforms in data.items():
+        for platform, info in platforms.items():
+            result.setdefault(version, {})[platform] = struct(
+                url = info["tarball"],
+                sha256 = info["shasum"],
+            )
+
+TOOL_VERSIONS = _parse("""\
+{
     "0.12.0": {
-        "aarch64-linux": struct(
-            url = "https://ziglang.org/download/0.12.0/zig-linux-aarch64-0.12.0.tar.xz",
-            integrity = "sha256-dU8QKUhAebfgyjuROgovKmr9WiiZDLIk/ohF5y8J3mM=",
-        ),
-        "aarch64-macos": struct(
-            url = "https://ziglang.org/download/0.12.0/zig-macos-aarch64-0.12.0.tar.xz",
-            integrity = "sha256-KU4iTBT9CCLPsVo1zzmqFL2ZZ4Z5mb+L3+Pbfd7Con8=",
-        ),
-        "aarch64-windows": struct(
-            url = "https://ziglang.org/download/0.12.0/zig-windows-aarch64-0.12.0.zip",
-            integrity = "sha256-BMa5JokkHKeopZtfEtLKKCDAnVBDw8SAi36T5Bx7+Xs=",
-        ),
-        "x86-linux": struct(
-            url = "https://ziglang.org/download/0.12.0/zig-linux-x86-0.12.0.tar.xz",
-            integrity = "sha256-+3UvzriHSagNYlpu/bI76oIIlitRUNbRTJLSDv2mKaU=",
-        ),
-        "x86-windows": struct(
-            url = "https://ziglang.org/download/0.12.0/zig-windows-x86-0.12.0.zip",
-            integrity = "sha256-SX3J/UFcrflIhy8TfWzAhwUHSI9525VHuPKttzzamYE=",
-        ),
-        "x86_64-linux": struct(
-            url = "https://ziglang.org/download/0.12.0/zig-linux-x86_64-0.12.0.tar.xz",
-            integrity = "sha256-x66Ga4p2pWji1c/TH+ic22Kb3RYf3VAYsppKChcEXK0=",
-        ),
-        "x86_64-macos": struct(
-            url = "https://ziglang.org/download/0.12.0/zig-macos-x86_64-0.12.0.tar.xz",
-            integrity = "sha256-TUEb9BPnZnghMk2iSOhYkngYDbwZf08oK327WZpokxE=",
-        ),
-        "x86_64-windows": struct(
-            url = "https://ziglang.org/download/0.12.0/zig-windows-x86_64-0.12.0.zip",
-            integrity = "sha256-IZnrTCAA3bH7qFunjx/PnB+4s+V2WPamJ6jlExMYk/U=",
-        ),
+        "aarch64-linux": {
+            "tarball": "https://ziglang.org/download/0.12.0/zig-linux-aarch64-0.12.0.tar.xz",
+            "shasum": "754f1029484079b7e0ca3b913a0a2f2a6afd5a28990cb224fe8845e72f09de63"
+        },
+        "aarch64-macos": {
+            "tarball": "https://ziglang.org/download/0.12.0/zig-macos-aarch64-0.12.0.tar.xz",
+            "shasum": "294e224c14fd0822cfb15a35cf39aa14bd9967867999bf8bdfe3db7ddec2a27f"
+        },
+        "aarch64-windows": {
+            "tarball": "https://ziglang.org/download/0.12.0/zig-windows-aarch64-0.12.0.zip",
+            "shasum": "04c6b92689241ca7a8a59b5f12d2ca2820c09d5043c3c4808b7e93e41c7bf97b"
+        },
+        "x86-linux": {
+            "tarball": "https://ziglang.org/download/0.12.0/zig-linux-x86-0.12.0.tar.xz",
+            "shasum": "fb752fceb88749a80d625a6efdb23bea8208962b5150d6d14c92d20efda629a5"
+        },
+        "x86-windows": {
+            "tarball": "https://ziglang.org/download/0.12.0/zig-windows-x86-0.12.0.zip",
+            "shasum": "497dc9fd415cadf948872f137d6cc0870507488f79db9547b8f2adb73cda9981"
+        },
+        "x86_64-linux": {
+            "tarball": "https://ziglang.org/download/0.12.0/zig-linux-x86_64-0.12.0.tar.xz",
+            "shasum": "c7ae866b8a76a568e2d5cfd31fe89cdb629bdd161fdd5018b29a4a0a17045cad"
+        },
+        "x86_64-macos": {
+            "tarball": "https://ziglang.org/download/0.12.0/zig-macos-x86_64-0.12.0.tar.xz",
+            "shasum": "4d411bf413e7667821324da248e8589278180dbc197f4f282b7dbb599a689311"
+        },
+        "x86_64-windows": {
+            "tarball": "https://ziglang.org/download/0.12.0/zig-windows-x86_64-0.12.0.zip",
+            "shasum": "2199eb4c2000ddb1fba85ba78f1fcf9c1fb8b3e57658f6a627a8e513131893f5"
+        }
     },
     "0.11.0": {
-        "aarch64-linux": struct(
-            url = "https://ziglang.org/download/0.11.0/zig-linux-aarch64-0.11.0.tar.xz",
-            integrity = "sha256-lW6wldi6RKxuvSf3yZVuR9kpN8EDv3VHRdCjnNql1MY=",
-        ),
-        "aarch64-macos": struct(
-            url = "https://ziglang.org/download/0.11.0/zig-macos-aarch64-0.11.0.tar.xz",
-            integrity = "sha256-xuv5J7sTpwfXQmdHSp9VMnTmSQb9Ib8cdaIL3oyt97I=",
-        ),
-        "aarch64-windows": struct(
-            url = "https://ziglang.org/download/0.11.0/zig-windows-aarch64-0.11.0.zip",
-            integrity = "sha256-XUvRPbXssN3HSSMeAPElwdMQh9cI6f+bRcT04T5IxmE=",
-        ),
-        "x86-linux": struct(
-            url = "https://ziglang.org/download/0.11.0/zig-linux-x86-0.11.0.tar.xz",
-            integrity = "sha256-ew3D4OBwrg4NIkCxiSr2ofn6rDUWyuJOV/eg57BGYqg=",
-        ),
-        "x86-windows": struct(
-            url = "https://ziglang.org/download/0.11.0/zig-windows-x86-0.11.0.zip",
-            integrity = "sha256-5ys2KJfyjGcWM+ZQqgUony5isVTvzKl3CURWyNrDrvo=",
-        ),
-        "x86_64-linux": struct(
-            url = "https://ziglang.org/download/0.11.0/zig-linux-x86_64-0.11.0.tar.xz",
-            integrity = "sha256-LQDnif7E9xeQpue/g/+R1WSUPF7oQ8X9lm78R0tCMEc=",
-        ),
-        "x86_64-macos": struct(
-            url = "https://ziglang.org/download/0.11.0/zig-macos-x86_64-0.11.0.tar.xz",
-            integrity = "sha256-HBxrmpBrQrquc2VuJOEI/YREu1C26P0D6eej+LXwVoY=",
-        ),
-        "x86_64-windows": struct(
-            url = "https://ziglang.org/download/0.11.0/zig-windows-x86_64-0.11.0.zip",
-            integrity = "sha256-FCyqO4BNhrR1JVbJtrA5t1F6CK+jr4QmRcfi3NEl9lI=",
-        ),
-    },
+        "aarch64-linux": {
+            "tarball": "https://ziglang.org/download/0.11.0/zig-linux-aarch64-0.11.0.tar.xz",
+            "shasum": "956eb095d8ba44ac6ebd27f7c9956e47d92937c103bf754745d0a39cdaa5d4c6"
+        },
+        "aarch64-macos": {
+            "tarball": "https://ziglang.org/download/0.11.0/zig-macos-aarch64-0.11.0.tar.xz",
+            "shasum": "c6ebf927bb13a707d74267474a9f553274e64906fd21bf1c75a20bde8cadf7b2"
+        },
+        "aarch64-windows": {
+            "tarball": "https://ziglang.org/download/0.11.0/zig-windows-aarch64-0.11.0.zip",
+            "shasum": "5d4bd13db5ecb0ddc749231e00f125c1d31087d708e9ff9b45c4f4e13e48c661"
+        },
+        "x86-linux": {
+            "tarball": "https://ziglang.org/download/0.11.0/zig-linux-x86-0.11.0.tar.xz",
+            "shasum": "7b0dc3e0e070ae0e0d2240b1892af6a1f9faac3516cae24e57f7a0e7b04662a8"
+        },
+        "x86-windows": {
+            "tarball": "https://ziglang.org/download/0.11.0/zig-windows-x86-0.11.0.zip",
+            "shasum": "e72b362897f28c671633e650aa05289f2e62b154efcca977094456c8dac3aefa"
+        },
+        "x86_64-linux": {
+            "tarball": "https://ziglang.org/download/0.11.0/zig-linux-x86_64-0.11.0.tar.xz",
+            "shasum": "2d00e789fec4f71790a6e7bf83ff91d564943c5ee843c5fd966efc474b423047"
+        },
+        "x86_64-macos": {
+            "tarball": "https://ziglang.org/download/0.11.0/zig-macos-x86_64-0.11.0.tar.xz",
+            "shasum": "1c1c6b9a906b42baae73656e24e108fd8444bb50b6e8fd03e9e7a3f8b5f05686"
+        },
+        "x86_64-windows": {
+            "tarball": "https://ziglang.org/download/0.11.0/zig-windows-x86_64-0.11.0.zip",
+            "shasum": "142caa3b804d86b4752556c9b6b039b7517a08afa3af842645c7e2dcd125f652"
+        }
+    }
 }
+""")
+
+# vim: ft=bzl

--- a/zig/private/versions.bzl
+++ b/zig/private/versions.bzl
@@ -4,14 +4,17 @@ Generated from https://ziglang.org/download/index.json.
 """
 
 def _parse(json_string):
-    data = json.decode(json_string)
     result = {}
+
+    data = json.decode(json_string)
     for version, platforms in data.items():
         for platform, info in platforms.items():
             result.setdefault(version, {})[platform] = struct(
                 url = info["tarball"],
                 sha256 = info["shasum"],
             )
+
+    return result
 
 TOOL_VERSIONS = _parse("""\
 {

--- a/zig/private/versions.bzl
+++ b/zig/private/versions.bzl
@@ -15,74 +15,74 @@ def _parse(json_string):
 
 TOOL_VERSIONS = _parse("""\
 {
-    "0.12.0": {
-        "aarch64-linux": {
-            "tarball": "https://ziglang.org/download/0.12.0/zig-linux-aarch64-0.12.0.tar.xz",
-            "shasum": "754f1029484079b7e0ca3b913a0a2f2a6afd5a28990cb224fe8845e72f09de63"
-        },
-        "aarch64-macos": {
-            "tarball": "https://ziglang.org/download/0.12.0/zig-macos-aarch64-0.12.0.tar.xz",
-            "shasum": "294e224c14fd0822cfb15a35cf39aa14bd9967867999bf8bdfe3db7ddec2a27f"
-        },
-        "aarch64-windows": {
-            "tarball": "https://ziglang.org/download/0.12.0/zig-windows-aarch64-0.12.0.zip",
-            "shasum": "04c6b92689241ca7a8a59b5f12d2ca2820c09d5043c3c4808b7e93e41c7bf97b"
-        },
-        "x86-linux": {
-            "tarball": "https://ziglang.org/download/0.12.0/zig-linux-x86-0.12.0.tar.xz",
-            "shasum": "fb752fceb88749a80d625a6efdb23bea8208962b5150d6d14c92d20efda629a5"
-        },
-        "x86-windows": {
-            "tarball": "https://ziglang.org/download/0.12.0/zig-windows-x86-0.12.0.zip",
-            "shasum": "497dc9fd415cadf948872f137d6cc0870507488f79db9547b8f2adb73cda9981"
-        },
-        "x86_64-linux": {
-            "tarball": "https://ziglang.org/download/0.12.0/zig-linux-x86_64-0.12.0.tar.xz",
-            "shasum": "c7ae866b8a76a568e2d5cfd31fe89cdb629bdd161fdd5018b29a4a0a17045cad"
-        },
-        "x86_64-macos": {
-            "tarball": "https://ziglang.org/download/0.12.0/zig-macos-x86_64-0.12.0.tar.xz",
-            "shasum": "4d411bf413e7667821324da248e8589278180dbc197f4f282b7dbb599a689311"
-        },
-        "x86_64-windows": {
-            "tarball": "https://ziglang.org/download/0.12.0/zig-windows-x86_64-0.12.0.zip",
-            "shasum": "2199eb4c2000ddb1fba85ba78f1fcf9c1fb8b3e57658f6a627a8e513131893f5"
-        }
+  "0.12.0": {
+    "aarch64-linux": {
+      "tarball": "https://ziglang.org/download/0.12.0/zig-linux-aarch64-0.12.0.tar.xz",
+      "shasum": "754f1029484079b7e0ca3b913a0a2f2a6afd5a28990cb224fe8845e72f09de63"
     },
-    "0.11.0": {
-        "aarch64-linux": {
-            "tarball": "https://ziglang.org/download/0.11.0/zig-linux-aarch64-0.11.0.tar.xz",
-            "shasum": "956eb095d8ba44ac6ebd27f7c9956e47d92937c103bf754745d0a39cdaa5d4c6"
-        },
-        "aarch64-macos": {
-            "tarball": "https://ziglang.org/download/0.11.0/zig-macos-aarch64-0.11.0.tar.xz",
-            "shasum": "c6ebf927bb13a707d74267474a9f553274e64906fd21bf1c75a20bde8cadf7b2"
-        },
-        "aarch64-windows": {
-            "tarball": "https://ziglang.org/download/0.11.0/zig-windows-aarch64-0.11.0.zip",
-            "shasum": "5d4bd13db5ecb0ddc749231e00f125c1d31087d708e9ff9b45c4f4e13e48c661"
-        },
-        "x86-linux": {
-            "tarball": "https://ziglang.org/download/0.11.0/zig-linux-x86-0.11.0.tar.xz",
-            "shasum": "7b0dc3e0e070ae0e0d2240b1892af6a1f9faac3516cae24e57f7a0e7b04662a8"
-        },
-        "x86-windows": {
-            "tarball": "https://ziglang.org/download/0.11.0/zig-windows-x86-0.11.0.zip",
-            "shasum": "e72b362897f28c671633e650aa05289f2e62b154efcca977094456c8dac3aefa"
-        },
-        "x86_64-linux": {
-            "tarball": "https://ziglang.org/download/0.11.0/zig-linux-x86_64-0.11.0.tar.xz",
-            "shasum": "2d00e789fec4f71790a6e7bf83ff91d564943c5ee843c5fd966efc474b423047"
-        },
-        "x86_64-macos": {
-            "tarball": "https://ziglang.org/download/0.11.0/zig-macos-x86_64-0.11.0.tar.xz",
-            "shasum": "1c1c6b9a906b42baae73656e24e108fd8444bb50b6e8fd03e9e7a3f8b5f05686"
-        },
-        "x86_64-windows": {
-            "tarball": "https://ziglang.org/download/0.11.0/zig-windows-x86_64-0.11.0.zip",
-            "shasum": "142caa3b804d86b4752556c9b6b039b7517a08afa3af842645c7e2dcd125f652"
-        }
+    "aarch64-macos": {
+      "tarball": "https://ziglang.org/download/0.12.0/zig-macos-aarch64-0.12.0.tar.xz",
+      "shasum": "294e224c14fd0822cfb15a35cf39aa14bd9967867999bf8bdfe3db7ddec2a27f"
+    },
+    "aarch64-windows": {
+      "tarball": "https://ziglang.org/download/0.12.0/zig-windows-aarch64-0.12.0.zip",
+      "shasum": "04c6b92689241ca7a8a59b5f12d2ca2820c09d5043c3c4808b7e93e41c7bf97b"
+    },
+    "x86-linux": {
+      "tarball": "https://ziglang.org/download/0.12.0/zig-linux-x86-0.12.0.tar.xz",
+      "shasum": "fb752fceb88749a80d625a6efdb23bea8208962b5150d6d14c92d20efda629a5"
+    },
+    "x86-windows": {
+      "tarball": "https://ziglang.org/download/0.12.0/zig-windows-x86-0.12.0.zip",
+      "shasum": "497dc9fd415cadf948872f137d6cc0870507488f79db9547b8f2adb73cda9981"
+    },
+    "x86_64-linux": {
+      "tarball": "https://ziglang.org/download/0.12.0/zig-linux-x86_64-0.12.0.tar.xz",
+      "shasum": "c7ae866b8a76a568e2d5cfd31fe89cdb629bdd161fdd5018b29a4a0a17045cad"
+    },
+    "x86_64-macos": {
+      "tarball": "https://ziglang.org/download/0.12.0/zig-macos-x86_64-0.12.0.tar.xz",
+      "shasum": "4d411bf413e7667821324da248e8589278180dbc197f4f282b7dbb599a689311"
+    },
+    "x86_64-windows": {
+      "tarball": "https://ziglang.org/download/0.12.0/zig-windows-x86_64-0.12.0.zip",
+      "shasum": "2199eb4c2000ddb1fba85ba78f1fcf9c1fb8b3e57658f6a627a8e513131893f5"
     }
+  },
+  "0.11.0": {
+    "aarch64-linux": {
+      "tarball": "https://ziglang.org/download/0.11.0/zig-linux-aarch64-0.11.0.tar.xz",
+      "shasum": "956eb095d8ba44ac6ebd27f7c9956e47d92937c103bf754745d0a39cdaa5d4c6"
+    },
+    "aarch64-macos": {
+      "tarball": "https://ziglang.org/download/0.11.0/zig-macos-aarch64-0.11.0.tar.xz",
+      "shasum": "c6ebf927bb13a707d74267474a9f553274e64906fd21bf1c75a20bde8cadf7b2"
+    },
+    "aarch64-windows": {
+      "tarball": "https://ziglang.org/download/0.11.0/zig-windows-aarch64-0.11.0.zip",
+      "shasum": "5d4bd13db5ecb0ddc749231e00f125c1d31087d708e9ff9b45c4f4e13e48c661"
+    },
+    "x86-linux": {
+      "tarball": "https://ziglang.org/download/0.11.0/zig-linux-x86-0.11.0.tar.xz",
+      "shasum": "7b0dc3e0e070ae0e0d2240b1892af6a1f9faac3516cae24e57f7a0e7b04662a8"
+    },
+    "x86-windows": {
+      "tarball": "https://ziglang.org/download/0.11.0/zig-windows-x86-0.11.0.zip",
+      "shasum": "e72b362897f28c671633e650aa05289f2e62b154efcca977094456c8dac3aefa"
+    },
+    "x86_64-linux": {
+      "tarball": "https://ziglang.org/download/0.11.0/zig-linux-x86_64-0.11.0.tar.xz",
+      "shasum": "2d00e789fec4f71790a6e7bf83ff91d564943c5ee843c5fd966efc474b423047"
+    },
+    "x86_64-macos": {
+      "tarball": "https://ziglang.org/download/0.11.0/zig-macos-x86_64-0.11.0.tar.xz",
+      "shasum": "1c1c6b9a906b42baae73656e24e108fd8444bb50b6e8fd03e9e7a3f8b5f05686"
+    },
+    "x86_64-windows": {
+      "tarball": "https://ziglang.org/download/0.11.0/zig-windows-x86_64-0.11.0.zip",
+      "shasum": "142caa3b804d86b4752556c9b6b039b7517a08afa3af842645c7e2dcd125f652"
+    }
+  }
 }
 """)
 

--- a/zig/private/versions.bzl.tpl
+++ b/zig/private/versions.bzl.tpl
@@ -4,14 +4,17 @@ Generated from https://ziglang.org/download/index.json.
 """
 
 def _parse(json_string):
-    data = json.decode(json_string)
     result = {}
+
+    data = json.decode(json_string)
     for version, platforms in data.items():
         for platform, info in platforms.items():
             result.setdefault(version, {})[platform] = struct(
                 url = info["tarball"],
                 sha256 = info["shasum"],
             )
+
+    return result
 
 TOOL_VERSIONS = _parse("""\
 $ZIG_VERSIONS_JSON

--- a/zig/private/versions.bzl.tpl
+++ b/zig/private/versions.bzl.tpl
@@ -1,0 +1,20 @@
+"""Mirror of Zig release info.
+
+Generated from https://ziglang.org/download/index.json.
+"""
+
+def _parse(json_string):
+    data = json.decode(json_string)
+    result = {}
+    for version, platforms in data.items():
+        for platform, info in platforms.items():
+            result.setdefault(version, {})[platform] = struct(
+                url = info["tarball"],
+                sha256 = info["shasum"],
+            )
+
+TOOL_VERSIONS = _parse("""\
+$ZIG_VERSIONS_JSON
+""")
+
+# vim: ft=bzl

--- a/zig/private/versions.json
+++ b/zig/private/versions.json
@@ -1,0 +1,70 @@
+{
+  "0.12.0": {
+    "aarch64-linux": {
+      "tarball": "https://ziglang.org/download/0.12.0/zig-linux-aarch64-0.12.0.tar.xz",
+      "shasum": "754f1029484079b7e0ca3b913a0a2f2a6afd5a28990cb224fe8845e72f09de63"
+    },
+    "aarch64-macos": {
+      "tarball": "https://ziglang.org/download/0.12.0/zig-macos-aarch64-0.12.0.tar.xz",
+      "shasum": "294e224c14fd0822cfb15a35cf39aa14bd9967867999bf8bdfe3db7ddec2a27f"
+    },
+    "aarch64-windows": {
+      "tarball": "https://ziglang.org/download/0.12.0/zig-windows-aarch64-0.12.0.zip",
+      "shasum": "04c6b92689241ca7a8a59b5f12d2ca2820c09d5043c3c4808b7e93e41c7bf97b"
+    },
+    "x86-linux": {
+      "tarball": "https://ziglang.org/download/0.12.0/zig-linux-x86-0.12.0.tar.xz",
+      "shasum": "fb752fceb88749a80d625a6efdb23bea8208962b5150d6d14c92d20efda629a5"
+    },
+    "x86-windows": {
+      "tarball": "https://ziglang.org/download/0.12.0/zig-windows-x86-0.12.0.zip",
+      "shasum": "497dc9fd415cadf948872f137d6cc0870507488f79db9547b8f2adb73cda9981"
+    },
+    "x86_64-linux": {
+      "tarball": "https://ziglang.org/download/0.12.0/zig-linux-x86_64-0.12.0.tar.xz",
+      "shasum": "c7ae866b8a76a568e2d5cfd31fe89cdb629bdd161fdd5018b29a4a0a17045cad"
+    },
+    "x86_64-macos": {
+      "tarball": "https://ziglang.org/download/0.12.0/zig-macos-x86_64-0.12.0.tar.xz",
+      "shasum": "4d411bf413e7667821324da248e8589278180dbc197f4f282b7dbb599a689311"
+    },
+    "x86_64-windows": {
+      "tarball": "https://ziglang.org/download/0.12.0/zig-windows-x86_64-0.12.0.zip",
+      "shasum": "2199eb4c2000ddb1fba85ba78f1fcf9c1fb8b3e57658f6a627a8e513131893f5"
+    }
+  },
+  "0.11.0": {
+    "aarch64-linux": {
+      "tarball": "https://ziglang.org/download/0.11.0/zig-linux-aarch64-0.11.0.tar.xz",
+      "shasum": "956eb095d8ba44ac6ebd27f7c9956e47d92937c103bf754745d0a39cdaa5d4c6"
+    },
+    "aarch64-macos": {
+      "tarball": "https://ziglang.org/download/0.11.0/zig-macos-aarch64-0.11.0.tar.xz",
+      "shasum": "c6ebf927bb13a707d74267474a9f553274e64906fd21bf1c75a20bde8cadf7b2"
+    },
+    "aarch64-windows": {
+      "tarball": "https://ziglang.org/download/0.11.0/zig-windows-aarch64-0.11.0.zip",
+      "shasum": "5d4bd13db5ecb0ddc749231e00f125c1d31087d708e9ff9b45c4f4e13e48c661"
+    },
+    "x86-linux": {
+      "tarball": "https://ziglang.org/download/0.11.0/zig-linux-x86-0.11.0.tar.xz",
+      "shasum": "7b0dc3e0e070ae0e0d2240b1892af6a1f9faac3516cae24e57f7a0e7b04662a8"
+    },
+    "x86-windows": {
+      "tarball": "https://ziglang.org/download/0.11.0/zig-windows-x86-0.11.0.zip",
+      "shasum": "e72b362897f28c671633e650aa05289f2e62b154efcca977094456c8dac3aefa"
+    },
+    "x86_64-linux": {
+      "tarball": "https://ziglang.org/download/0.11.0/zig-linux-x86_64-0.11.0.tar.xz",
+      "shasum": "2d00e789fec4f71790a6e7bf83ff91d564943c5ee843c5fd966efc474b423047"
+    },
+    "x86_64-macos": {
+      "tarball": "https://ziglang.org/download/0.11.0/zig-macos-x86_64-0.11.0.tar.xz",
+      "shasum": "1c1c6b9a906b42baae73656e24e108fd8444bb50b6e8fd03e9e7a3f8b5f05686"
+    },
+    "x86_64-windows": {
+      "tarball": "https://ziglang.org/download/0.11.0/zig-windows-x86_64-0.11.0.zip",
+      "shasum": "142caa3b804d86b4752556c9b6b039b7517a08afa3af842645c7e2dcd125f652"
+    }
+  }
+}

--- a/zig/repositories.bzl
+++ b/zig/repositories.bzl
@@ -56,7 +56,7 @@ def zig_repository(*, name, zig_version, platform, **kwargs):
     _zig_repository(
         name = name,
         url = TOOL_VERSIONS[zig_version][platform].url,
-        integrity = TOOL_VERSIONS[zig_version][platform].integrity,
+        sha256 = TOOL_VERSIONS[zig_version][platform].sha256,
         zig_version = zig_version,
         platform = platform,
         **kwargs

--- a/zig/tests/bzlmod_zig_test.bzl
+++ b/zig/tests/bzlmod_zig_test.bzl
@@ -2,15 +2,15 @@
 
 load("@bazel_skylib//lib:partial.bzl", "partial")
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
-load("//zig/private/bzlmod:zig.bzl", "DEFAULT_VERSION", "handle_tags")
+load("//zig/private/bzlmod:zig.bzl", "handle_tags")
 
 def _zig_versions_test_impl(ctx):
     env = unittest.begin(ctx)
 
     asserts.equals(
         env,
-        (None, [DEFAULT_VERSION]),
-        handle_tags(struct(modules = [])),
+        (None, ["0.1.0"]),
+        handle_tags(struct(modules = []), known_versions = ["0.1.0"]),
         "should fall back to the default Zig SDK version",
     )
 
@@ -31,7 +31,7 @@ def _zig_versions_test_impl(ctx):
                     ),
                 ),
             ],
-        )),
+        ), known_versions = ["0.1.0"]),
         "should choose a single configured version",
     )
 
@@ -71,7 +71,7 @@ def _zig_versions_test_impl(ctx):
                     ),
                 ),
             ],
-        )),
+        ), known_versions = ["0.4.0", "0.2.0", "0.1.0", "0.0.1"]),
         "should order versions by semver",
     )
 
@@ -111,7 +111,7 @@ def _zig_versions_test_impl(ctx):
                     ),
                 ),
             ],
-        )),
+        ), known_versions = ["0.1.0", "0.0.1"]),
         "should deduplicate versions",
     )
 
@@ -151,7 +151,7 @@ def _zig_versions_test_impl(ctx):
                     ),
                 ),
             ],
-        )),
+        ), known_versions = ["0.4.0", "0.2.0", "0.1.0", "0.0.1"]),
         "the default should take precedence",
     )
 
@@ -191,7 +191,7 @@ def _zig_versions_test_impl(ctx):
                     ),
                 ),
             ],
-        )),
+        ), known_versions = ["0.2.0", "0.1.0", "0.0.1"]),
         "should not duplicate default",
     )
 
@@ -215,7 +215,7 @@ def _zig_versions_test_impl(ctx):
                     ),
                 ),
             ],
-        )),
+        ), known_versions = ["0.1.0"]),
         "only root may set default",
     )
 
@@ -243,7 +243,7 @@ def _zig_versions_test_impl(ctx):
                     ),
                 ),
             ],
-        )),
+        ), known_versions = ["0.2.0", "0.1.0"]),
         "only one default allowed",
     )
 


### PR DESCRIPTION
Generate and check in a JSON file that tracks the available Zig versions.
The format is compatible with the upstream index format at https://ziglang.org/download/index.json.
The zig module extension no longer depends on the `TOOL_VERSIONS` constant and instead reads the JSON file in its module extension implementation function.
This is a step toward user defined Zig versions and relevant to #76.

- **sort imports**
- **update_zig_versions.py: generate JSON not bzl**
- **Generate versions.json file**
- **update the Zig update workflow**
- **Generate versions.bzl based on JSON data**
- **Generate a new JSON based versions.bzl**
- **Consistent JSON indentation**
- **Consistent JSON encoding - line ending**
- **Fix missing return value**
- **integrity -> sha256**
- **Update Zig version update workflow**
- **bzlmod - Load known Zig versions from JSON**
- **bzlmod - remove dependency on TOOL_VERSIONS**
- **update generated files**
