### PR TITLE
feat: support user defined version index (incl. pre-release)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,6 +9,7 @@ bazel_dep(name = "bazel_skylib", version = "1.6.1")
 bazel_dep(name = "platforms", version = "0.0.10")
 
 zig = use_extension("//zig:extensions.bzl", "zig")
+zig.index(file = "//zig/private:versions.json")
 use_repo(zig, "zig_toolchains")
 
 register_toolchains("@rules_zig//zig/target:all")

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -30,7 +30,7 @@ declares one as the default.
 
 Fetch and define toolchain targets for the given Zig SDK version.
 
-Defaults to the latest known release version.
+Defaults to the latest known version.
 
 **Attributes**
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -9,6 +9,7 @@ Extensions for bzlmod.
 <pre>
 zig = use_extension("@rules_zig//zig:extensions.bzl", "zig")
 zig.toolchain(<a href="#zig.toolchain-default">default</a>, <a href="#zig.toolchain-zig_version">zig_version</a>)
+zig.index(<a href="#zig.index-file">file</a>)
 </pre>
 
 Installs a Zig toolchain.
@@ -27,11 +28,31 @@ declares one as the default.
 
 ### toolchain
 
+Fetch and define toolchain targets for the given Zig SDK version.
+
+Defaults to the latest known release version.
+
 **Attributes**
 
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="zig.toolchain-default"></a>default |  Make this the default Zig SDK version. Can only be used once, and only in the root module.   | Boolean | optional |  `False`  |
 | <a id="zig.toolchain-zig_version"></a>zig_version |  The Zig SDK version.   | String | required |  |
+
+<a id="zig.index"></a>
+
+### index
+
+Extend the set of known Zig SDK versions based on a Zig version index.
+
+The provided index must use a schema that is compatible with the [upstream index].
+
+[upstream index]: https://ziglang.org/download/index.json
+
+**Attributes**
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="zig.index-file"></a>file |  The Zig version index JSON file.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
 
 

--- a/zig/private/bzlmod/zig.bzl
+++ b/zig/private/bzlmod/zig.bzl
@@ -118,7 +118,7 @@ def parse_zig_versions_json(json_string):
             version = platforms["version"]
 
         for platform, info in platforms.items():
-            if type(info) != "dict":
+            if type(info) != "dict" or not platform in PLATFORMS:
                 continue
 
             if not "tarball" in info:

--- a/zig/private/bzlmod/zig.bzl
+++ b/zig/private/bzlmod/zig.bzl
@@ -19,14 +19,21 @@ declares one as the default.
 
 _DEFAULT_NAME = "zig"
 
-zig_toolchain = tag_class(attrs = {
-    "zig_version": attr.string(doc = "The Zig SDK version.", mandatory = True),
-    "default": attr.bool(
-        doc = "Make this the default Zig SDK version. Can only be used once, and only in the root module.",
-        mandatory = False,
-        default = False,
-    ),
-})
+zig_toolchain = tag_class(
+    attrs = {
+        "zig_version": attr.string(doc = "The Zig SDK version.", mandatory = True),
+        "default": attr.bool(
+            doc = "Make this the default Zig SDK version. Can only be used once, and only in the root module.",
+            mandatory = False,
+            default = False,
+        ),
+    },
+    doc = """\
+Fetch and define toolchain targets for the given Zig SDK version.
+
+Defaults to the latest known release version.
+""",
+)
 
 zig_index = tag_class(
     attrs = {

--- a/zig/private/bzlmod/zig.bzl
+++ b/zig/private/bzlmod/zig.bzl
@@ -105,7 +105,7 @@ def _parse_zig_versions_json(json_string):
                 sha256 = info["shasum"],
             )
 
-    return result
+    return None, result
 
 def _merge_version_specs(version_specs):
     result = {}
@@ -123,7 +123,11 @@ def _toolchain_extension(module_ctx):
         for index in mod.tags.index:
             file_path = module_ctx.path(index.file)
             file_content = module_ctx.read(file_path)
-            parsed = _parse_zig_versions_json(file_content)
+            (err, parsed) = _parse_zig_versions_json(file_content)
+
+            if err != None:
+                fail(err, index)
+
             version_specs.append(parsed)
 
     known_versions = _merge_version_specs(version_specs)

--- a/zig/private/bzlmod/zig.bzl
+++ b/zig/private/bzlmod/zig.bzl
@@ -114,7 +114,13 @@ def parse_zig_versions_json(json_string):
         return "Invalid JSON format in Zig SDK version index.", None
 
     for version, platforms in data.items():
+        if "version" in platforms:
+            version = platforms["version"]
+
         for platform, info in platforms.items():
+            if type(info) != "dict":
+                continue
+
             if not "tarball" in info:
                 return "Missing `tarball` field in Zig SDK version index.", None
 

--- a/zig/private/bzlmod/zig.bzl
+++ b/zig/private/bzlmod/zig.bzl
@@ -137,7 +137,17 @@ def parse_zig_versions_json(json_string):
 
     return None, result
 
-def _merge_version_specs(version_specs):
+def merge_version_specs(version_specs):
+    """Merge Zig SDK version indices.
+
+    Exposed as a standalone function for unit testing.
+
+    Args:
+      version_specs: sequence of `dict[version, dict[platform, struct(url, sha256)]]`.
+
+    Returns:
+      `dict[version, dict[platform, struct(url, sha256)]]`
+    """
     result = {}
 
     for spec in version_specs:
@@ -160,7 +170,7 @@ def _toolchain_extension(module_ctx):
 
             version_specs.append(parsed)
 
-    known_versions = _merge_version_specs(version_specs)
+    known_versions = merge_version_specs(version_specs)
 
     (err, versions) = handle_toolchain_tags(module_ctx.modules, known_versions = known_versions)
 

--- a/zig/private/bzlmod/zig.bzl
+++ b/zig/private/bzlmod/zig.bzl
@@ -31,7 +31,7 @@ zig_toolchain = tag_class(
     doc = """\
 Fetch and define toolchain targets for the given Zig SDK version.
 
-Defaults to the latest known release version.
+Defaults to the latest known version.
 """,
 )
 

--- a/zig/private/bzlmod/zig.bzl
+++ b/zig/private/bzlmod/zig.bzl
@@ -53,13 +53,13 @@ TAG_CLASSES = {
     "index": zig_index,
 }
 
-def handle_toolchain_tags(module_ctx, *, known_versions):
+def handle_toolchain_tags(modules, *, known_versions):
     """Handle the zig module extension's toolchain tags.
 
     Exposed as a standalone function for unit testing.
 
     Args:
-      module_ctx: The module context object.
+      modules: sequence of module objects.
       known_versions: sequence of string, The set of known Zig versions.
 
     Returns:
@@ -68,7 +68,7 @@ def handle_toolchain_tags(module_ctx, *, known_versions):
     default = None
     versions = sets.make()
 
-    for mod in module_ctx.modules:
+    for mod in modules:
         for toolchain in mod.tags.toolchain:
             if toolchain.default:
                 if not mod.is_root:
@@ -111,7 +111,7 @@ def _toolchain_extension(module_ctx):
     zig_versions_json_path = module_ctx.path(Label("//zig/private:versions.json"))
     known_versions = _parse_zig_versions_json(module_ctx.read(zig_versions_json_path))
 
-    (err, versions) = handle_toolchain_tags(module_ctx, known_versions = known_versions)
+    (err, versions) = handle_toolchain_tags(module_ctx.modules, known_versions = known_versions)
 
     if err != None:
         fail(*err)

--- a/zig/private/bzlmod/zig.bzl
+++ b/zig/private/bzlmod/zig.bzl
@@ -28,8 +28,22 @@ zig_toolchain = tag_class(attrs = {
     ),
 })
 
+zig_index = tag_class(
+    attrs = {
+        "file": attr.label(doc = "The Zig version index JSON file.", mandatory = True),
+    },
+    doc = """\
+Extend the set of known Zig SDK versions based on a Zig version index.
+
+The provided index must use a schema that is compatible with the [upstream index].
+
+[upstream index]: https://ziglang.org/download/index.json
+""",
+)
+
 TAG_CLASSES = {
     "toolchain": zig_toolchain,
+    "index": zig_index,
 }
 
 def handle_tags(module_ctx, *, known_versions):

--- a/zig/private/bzlmod/zig.bzl
+++ b/zig/private/bzlmod/zig.bzl
@@ -117,6 +117,9 @@ def parse_zig_versions_json(json_string):
         if "version" in platforms:
             version = platforms["version"]
 
+        if not semver.is_valid(version):
+            return "Malformed version number '{}' in Zig SDK version index.".format(version), None
+
         for platform, info in platforms.items():
             if type(info) != "dict" or not platform in PLATFORMS:
                 continue

--- a/zig/private/bzlmod/zig.bzl
+++ b/zig/private/bzlmod/zig.bzl
@@ -53,8 +53,8 @@ TAG_CLASSES = {
     "index": zig_index,
 }
 
-def handle_tags(module_ctx, *, known_versions):
-    """Handle the zig module extension tags.
+def handle_toolchain_tags(module_ctx, *, known_versions):
+    """Handle the zig module extension's toolchain tags.
 
     Exposed as a standalone function for unit testing.
 
@@ -111,7 +111,7 @@ def _toolchain_extension(module_ctx):
     zig_versions_json_path = module_ctx.path(Label("//zig/private:versions.json"))
     known_versions = _parse_zig_versions_json(module_ctx.read(zig_versions_json_path))
 
-    (err, versions) = handle_tags(module_ctx, known_versions = known_versions)
+    (err, versions) = handle_toolchain_tags(module_ctx, known_versions = known_versions)
 
     if err != None:
         fail(*err)

--- a/zig/private/bzlmod/zig.bzl
+++ b/zig/private/bzlmod/zig.bzl
@@ -108,9 +108,19 @@ def parse_zig_versions_json(json_string):
     """
     result = {}
 
-    data = json.decode(json_string)
+    data = json.decode(json_string, default = None)
+
+    if data == None:
+        return "Invalid JSON format in Zig SDK version index.", None
+
     for version, platforms in data.items():
         for platform, info in platforms.items():
+            if not "tarball" in info:
+                return "Missing `tarball` field in Zig SDK version index.", None
+
+            if not "shasum" in info:
+                return "Missing `shasum` field in Zig SDK version index.", None
+
             result.setdefault(version, {})[platform] = struct(
                 url = info["tarball"],
                 sha256 = info["shasum"],

--- a/zig/private/bzlmod/zig.bzl
+++ b/zig/private/bzlmod/zig.bzl
@@ -94,7 +94,18 @@ def handle_toolchain_tags(modules, *, known_versions):
 
     return None, versions
 
-def _parse_zig_versions_json(json_string):
+def parse_zig_versions_json(json_string):
+    """Parse a Zig SDK versions index in JSON format.
+
+    Exposed as a standalone function for unit testing.
+
+    Args:
+      json_string: String, The version index in JSON format.
+
+    Returns:
+      (err, data), maybe an error or a
+        `dict[version, dict[platform, struct(url, sha256)]]`.
+    """
     result = {}
 
     data = json.decode(json_string)
@@ -123,7 +134,7 @@ def _toolchain_extension(module_ctx):
         for index in mod.tags.index:
             file_path = module_ctx.path(index.file)
             file_content = module_ctx.read(file_path)
-            (err, parsed) = _parse_zig_versions_json(file_content)
+            (err, parsed) = parse_zig_versions_json(file_content)
 
             if err != None:
                 fail(err, index)

--- a/zig/private/common/semver.bzl
+++ b/zig/private/common/semver.bzl
@@ -63,6 +63,19 @@ def _grouped(versions):
         patch = patch,
     )
 
+def _is_valid(version):
+    """Validate the formatting of a semantic version."""
+    if version.count(".") < 2:
+        return False
+
+    v = _split(version)
+
+    return all([
+        v.major.isdigit(),
+        v.minor.isdigit(),
+        v.patch.isdigit(),
+    ])
+
 def _parse_pre_release_component(component):
     """Parse a pre-release component for sorting."""
     num = float("+Infinity")
@@ -101,4 +114,5 @@ def _sorted(versions, *, reverse = False):
 semver = struct(
     grouped = _grouped,
     sorted = _sorted,
+    is_valid = _is_valid,
 )

--- a/zig/tests/bzlmod_zig_test.bzl
+++ b/zig/tests/bzlmod_zig_test.bzl
@@ -195,6 +195,20 @@ def _parse_zig_index_test_impl(ctx):
     result = parse_zig_versions_json(content)
     asserts.equals(env, (expected_err, None), result)
 
+    content = """\
+{
+  "bad-version": {
+    "aarch64-linux": {
+      "tarball": "https://ziglang.org/download/0.12.0/zig-linux-aarch64-0.12.0.tar.xz",
+      "shasum": "754f1029484079b7e0ca3b913a0a2f2a6afd5a28990cb224fe8845e72f09de63"
+    }
+  }
+}
+"""
+    expected_err = "Malformed version number in Zig SDK version index."
+    result = parse_zig_versions_json(content)
+    asserts.equals(env, (expected_err, None), result)
+
     return unittest.end(env)
 
 _parse_zig_index_test = unittest.make(

--- a/zig/tests/bzlmod_zig_test.bzl
+++ b/zig/tests/bzlmod_zig_test.bzl
@@ -2,7 +2,7 @@
 
 load("@bazel_skylib//lib:partial.bzl", "partial")
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
-load("//zig/private/bzlmod:zig.bzl", "handle_tags")
+load("//zig/private/bzlmod:zig.bzl", "handle_toolchain_tags")
 
 def _zig_versions_test_impl(ctx):
     env = unittest.begin(ctx)
@@ -10,14 +10,14 @@ def _zig_versions_test_impl(ctx):
     asserts.equals(
         env,
         (None, ["0.1.0"]),
-        handle_tags(struct(modules = []), known_versions = ["0.1.0"]),
+        handle_toolchain_tags(struct(modules = []), known_versions = ["0.1.0"]),
         "should fall back to the default Zig SDK version",
     )
 
     asserts.equals(
         env,
         (None, ["0.1.0"]),
-        handle_tags(struct(
+        handle_toolchain_tags(struct(
             modules = [
                 struct(
                     is_root = False,
@@ -38,7 +38,7 @@ def _zig_versions_test_impl(ctx):
     asserts.equals(
         env,
         (None, ["0.4.0", "0.2.0", "0.1.0", "0.0.1"]),
-        handle_tags(struct(
+        handle_toolchain_tags(struct(
             modules = [
                 struct(
                     is_root = False,
@@ -78,7 +78,7 @@ def _zig_versions_test_impl(ctx):
     asserts.equals(
         env,
         (None, ["0.1.0", "0.0.1"]),
-        handle_tags(struct(
+        handle_toolchain_tags(struct(
             modules = [
                 struct(
                     is_root = False,
@@ -118,7 +118,7 @@ def _zig_versions_test_impl(ctx):
     asserts.equals(
         env,
         (None, ["0.1.0", "0.4.0", "0.2.0", "0.0.1"]),
-        handle_tags(struct(
+        handle_toolchain_tags(struct(
             modules = [
                 struct(
                     is_root = False,
@@ -158,7 +158,7 @@ def _zig_versions_test_impl(ctx):
     asserts.equals(
         env,
         (None, ["0.1.0", "0.2.0", "0.0.1"]),
-        handle_tags(struct(
+        handle_toolchain_tags(struct(
             modules = [
                 struct(
                     is_root = False,
@@ -201,7 +201,7 @@ def _zig_versions_test_impl(ctx):
             default = True,
             zig_version = "0.1.0",
         )], None),
-        handle_tags(struct(
+        handle_toolchain_tags(struct(
             modules = [
                 struct(
                     is_root = False,
@@ -225,7 +225,7 @@ def _zig_versions_test_impl(ctx):
             default = True,
             zig_version = "0.2.0",
         )], None),
-        handle_tags(struct(
+        handle_toolchain_tags(struct(
             modules = [
                 struct(
                     is_root = True,

--- a/zig/tests/bzlmod_zig_test.bzl
+++ b/zig/tests/bzlmod_zig_test.bzl
@@ -78,6 +78,37 @@ def _parse_zig_index_test_impl(ctx):
     result = parse_zig_versions_json(content)
     asserts.equals(env, (None, expected), result)
 
+    content = ""
+    expected_err = "Invalid JSON format in Zig SDK version index."
+    result = parse_zig_versions_json(content)
+    asserts.equals(env, (expected_err, None), result)
+
+    content = """\
+{
+  "0.12.0": {
+    "aarch64-linux": {
+      "shasum": "754f1029484079b7e0ca3b913a0a2f2a6afd5a28990cb224fe8845e72f09de63"
+    }
+  }
+}
+"""
+    expected_err = "Missing `tarball` field in Zig SDK version index."
+    result = parse_zig_versions_json(content)
+    asserts.equals(env, (expected_err, None), result)
+
+    content = """\
+{
+  "0.12.0": {
+    "aarch64-linux": {
+      "tarball": "https://ziglang.org/download/0.12.0/zig-linux-aarch64-0.12.0.tar.xz"
+    }
+  }
+}
+"""
+    expected_err = "Missing `shasum` field in Zig SDK version index."
+    result = parse_zig_versions_json(content)
+    asserts.equals(env, (expected_err, None), result)
+
     return unittest.end(env)
 
 _parse_zig_index_test = unittest.make(

--- a/zig/tests/bzlmod_zig_test.bzl
+++ b/zig/tests/bzlmod_zig_test.bzl
@@ -5,6 +5,7 @@ load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 load(
     "//zig/private/bzlmod:zig.bzl",
     "handle_toolchain_tags",
+    "merge_version_specs",
     "parse_zig_versions_json",
 )
 
@@ -213,6 +214,67 @@ def _parse_zig_index_test_impl(ctx):
 
 _parse_zig_index_test = unittest.make(
     _parse_zig_index_test_impl,
+)
+
+def _merge_version_specs_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    asserts.equals(
+        env,
+        {},
+        merge_version_specs([]),
+    )
+
+    asserts.equals(
+        env,
+        {
+            "0.12.0": {
+                "aarch64-linux": struct(
+                    url = "https://ziglang.org/download/0.12.0/zig-linux-aarch64-0.12.0.tar.xz",
+                    sha256 = "754f1029484079b7e0ca3b913a0a2f2a6afd5a28990cb224fe8845e72f09de63",
+                ),
+            },
+            "0.11.0": {
+                "aarch64-linux": struct(
+                    url = "https://ziglang.org/download/0.11.0/zig-linux-aarch64-0.11.0.tar.xz",
+                    sha256 = "956eb095d8ba44ac6ebd27f7c9956e47d92937c103bf754745d0a39cdaa5d4c6",
+                ),
+                "aarch64-macos": struct(
+                    url = "https://ziglang.org/download/0.11.0/zig-macos-aarch64-0.11.0.tar.xz",
+                    sha256 = "c6ebf927bb13a707d74267474a9f553274e64906fd21bf1c75a20bde8cadf7b2",
+                ),
+            },
+        },
+        merge_version_specs([
+            {
+                "0.12.0": {
+                    "aarch64-linux": struct(
+                        url = "https://ziglang.org/download/0.12.0/zig-linux-aarch64-0.12.0.tar.xz",
+                        sha256 = "754f1029484079b7e0ca3b913a0a2f2a6afd5a28990cb224fe8845e72f09de63",
+                    ),
+                },
+                "0.11.0": {
+                    "aarch64-macos": struct(
+                        url = "https://ziglang.org/download/0.11.0/zig-macos-aarch64-0.11.0.tar.xz",
+                        sha256 = "c6ebf927bb13a707d74267474a9f553274e64906fd21bf1c75a20bde8cadf7b2",
+                    ),
+                },
+            },
+            {
+                "0.11.0": {
+                    "aarch64-linux": struct(
+                        url = "https://ziglang.org/download/0.11.0/zig-linux-aarch64-0.11.0.tar.xz",
+                        sha256 = "956eb095d8ba44ac6ebd27f7c9956e47d92937c103bf754745d0a39cdaa5d4c6",
+                    ),
+                },
+            },
+        ]),
+    )
+
+    return unittest.end(env)
+
+_merge_version_specs_test = unittest.make(
+    _merge_version_specs_test_impl,
 )
 
 def _zig_versions_test_impl(ctx):
@@ -475,5 +537,6 @@ def bzlmod_zig_test_suite(name):
     unittest.suite(
         name,
         partial.make(_zig_versions_test, size = "small"),
+        partial.make(_merge_version_specs_test, size = "small"),
         partial.make(_parse_zig_index_test, size = "small"),
     )

--- a/zig/tests/bzlmod_zig_test.bzl
+++ b/zig/tests/bzlmod_zig_test.bzl
@@ -2,7 +2,87 @@
 
 load("@bazel_skylib//lib:partial.bzl", "partial")
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
-load("//zig/private/bzlmod:zig.bzl", "handle_toolchain_tags")
+load(
+    "//zig/private/bzlmod:zig.bzl",
+    "handle_toolchain_tags",
+    "parse_zig_versions_json",
+)
+
+def _parse_zig_index_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    content = "{}"
+    expected = {}
+    result = parse_zig_versions_json(content)
+    asserts.equals(env, (None, expected), result)
+
+    content = """\
+{
+  "0.12.0": {
+    "aarch64-linux": {
+      "tarball": "https://ziglang.org/download/0.12.0/zig-linux-aarch64-0.12.0.tar.xz",
+      "shasum": "754f1029484079b7e0ca3b913a0a2f2a6afd5a28990cb224fe8845e72f09de63"
+    }
+  }
+}
+"""
+    expected = {
+        "0.12.0": {
+            "aarch64-linux": struct(
+                url = "https://ziglang.org/download/0.12.0/zig-linux-aarch64-0.12.0.tar.xz",
+                sha256 = "754f1029484079b7e0ca3b913a0a2f2a6afd5a28990cb224fe8845e72f09de63",
+            ),
+        },
+    }
+    result = parse_zig_versions_json(content)
+    asserts.equals(env, (None, expected), result)
+
+    content = """\
+{
+  "0.12.0": {
+    "aarch64-linux": {
+      "tarball": "https://ziglang.org/download/0.12.0/zig-linux-aarch64-0.12.0.tar.xz",
+      "shasum": "754f1029484079b7e0ca3b913a0a2f2a6afd5a28990cb224fe8845e72f09de63"
+    }
+  },
+  "0.11.0": {
+    "aarch64-linux": {
+      "tarball": "https://ziglang.org/download/0.11.0/zig-linux-aarch64-0.11.0.tar.xz",
+      "shasum": "956eb095d8ba44ac6ebd27f7c9956e47d92937c103bf754745d0a39cdaa5d4c6"
+    },
+    "aarch64-macos": {
+      "tarball": "https://ziglang.org/download/0.11.0/zig-macos-aarch64-0.11.0.tar.xz",
+      "shasum": "c6ebf927bb13a707d74267474a9f553274e64906fd21bf1c75a20bde8cadf7b2"
+    }
+  }
+}
+"""
+    expected = {
+        "0.12.0": {
+            "aarch64-linux": struct(
+                url = "https://ziglang.org/download/0.12.0/zig-linux-aarch64-0.12.0.tar.xz",
+                sha256 = "754f1029484079b7e0ca3b913a0a2f2a6afd5a28990cb224fe8845e72f09de63",
+            ),
+        },
+        "0.11.0": {
+            "aarch64-linux": struct(
+                url = "https://ziglang.org/download/0.11.0/zig-linux-aarch64-0.11.0.tar.xz",
+                sha256 = "956eb095d8ba44ac6ebd27f7c9956e47d92937c103bf754745d0a39cdaa5d4c6",
+            ),
+            "aarch64-macos": struct(
+                url = "https://ziglang.org/download/0.11.0/zig-macos-aarch64-0.11.0.tar.xz",
+                sha256 = "c6ebf927bb13a707d74267474a9f553274e64906fd21bf1c75a20bde8cadf7b2",
+            ),
+        },
+    }
+    result = parse_zig_versions_json(content)
+    asserts.equals(env, (None, expected), result)
+
+    return unittest.end(env)
+
+_parse_zig_index_test = unittest.make(
+    _parse_zig_index_test_impl,
+)
 
 def _zig_versions_test_impl(ctx):
     env = unittest.begin(ctx)
@@ -264,4 +344,5 @@ def bzlmod_zig_test_suite(name):
     unittest.suite(
         name,
         partial.make(_zig_versions_test, size = "small"),
+        partial.make(_parse_zig_index_test, size = "small"),
     )

--- a/zig/tests/bzlmod_zig_test.bzl
+++ b/zig/tests/bzlmod_zig_test.bzl
@@ -101,6 +101,69 @@ def _parse_zig_index_test_impl(ctx):
     result = parse_zig_versions_json(content)
     asserts.equals(env, (None, expected), result)
 
+    content = """\
+{
+  "master": {
+    "version": "0.13.0-dev.46+3648d7df1",
+    "date": "2024-04-26",
+    "docs": "https://ziglang.org/documentation/master/",
+    "stdDocs": "https://ziglang.org/documentation/master/std/",
+    "src": {
+      "tarball": "https://ziglang.org/builds/zig-0.13.0-dev.46+3648d7df1.tar.xz",
+      "shasum": "08190cb4482be355acaecaae9d7936e4fad47180c97ca8138b97a122a313cd99",
+      "size": "17111524"
+    },
+    "bootstrap": {
+      "tarball": "https://ziglang.org/builds/zig-bootstrap-0.13.0-dev.46+3648d7df1.tar.xz",
+      "shasum": "78569b44dbfb8ec0cddbd1fa69ce398b973bd05c7f3b87f070cc2a0ba9c86571",
+      "size": "45555796"
+    },
+    "x86_64-macos": {
+      "tarball": "https://ziglang.org/builds/zig-macos-x86_64-0.13.0-dev.46+3648d7df1.tar.xz",
+      "shasum": "d8fb090bd69d7e191a3443520da5c52da430fbffc0de12ac87a114a6cc1f20ca",
+      "size": "47206948"
+    }
+  },
+  "0.12.0": {
+    "date": "2024-04-20",
+    "docs": "https://ziglang.org/documentation/0.12.0/",
+    "stdDocs": "https://ziglang.org/documentation/0.12.0/std/",
+    "notes": "https://ziglang.org/download/0.12.0/release-notes.html",
+    "src": {
+      "tarball": "https://ziglang.org/download/0.12.0/zig-0.12.0.tar.xz",
+      "shasum": "a6744ef84b6716f976dad923075b2f54dc4f785f200ae6c8ea07997bd9d9bd9a",
+      "size": "17099152"
+    },
+    "bootstrap": {
+      "tarball": "https://ziglang.org/download/0.12.0/zig-bootstrap-0.12.0.tar.xz",
+      "shasum": "3efc643d56421fa68072af94d5512cb71c61acf1c32512f77c0b4590bff63187",
+      "size": "45527312"
+    },
+    "x86_64-macos": {
+      "tarball": "https://ziglang.org/download/0.12.0/zig-macos-x86_64-0.12.0.tar.xz",
+      "shasum": "4d411bf413e7667821324da248e8589278180dbc197f4f282b7dbb599a689311",
+      "size": "47185720"
+    }
+  }
+}
+"""
+    expected = {
+        "0.13.0-dev.46+3648d7df1": {
+            "x86_64-macos": struct(
+                url = "https://ziglang.org/builds/zig-macos-x86_64-0.13.0-dev.46+3648d7df1.tar.xz",
+                sha256 = "d8fb090bd69d7e191a3443520da5c52da430fbffc0de12ac87a114a6cc1f20ca",
+            ),
+        },
+        "0.12.0": {
+            "x86_64-macos": struct(
+                url = "https://ziglang.org/download/0.12.0/zig-macos-x86_64-0.12.0.tar.xz",
+                sha256 = "4d411bf413e7667821324da248e8589278180dbc197f4f282b7dbb599a689311",
+            ),
+        },
+    }
+    result = parse_zig_versions_json(content)
+    asserts.equals(env, (None, expected), result)
+
     content = ""
     expected_err = "Invalid JSON format in Zig SDK version index."
     result = parse_zig_versions_json(content)

--- a/zig/tests/bzlmod_zig_test.bzl
+++ b/zig/tests/bzlmod_zig_test.bzl
@@ -10,15 +10,15 @@ def _zig_versions_test_impl(ctx):
     asserts.equals(
         env,
         (None, ["0.1.0"]),
-        handle_toolchain_tags(struct(modules = []), known_versions = ["0.1.0"]),
+        handle_toolchain_tags([], known_versions = ["0.1.0"]),
         "should fall back to the default Zig SDK version",
     )
 
     asserts.equals(
         env,
         (None, ["0.1.0"]),
-        handle_toolchain_tags(struct(
-            modules = [
+        handle_toolchain_tags(
+            [
                 struct(
                     is_root = False,
                     tags = struct(
@@ -31,15 +31,16 @@ def _zig_versions_test_impl(ctx):
                     ),
                 ),
             ],
-        ), known_versions = ["0.1.0"]),
+            known_versions = ["0.1.0"],
+        ),
         "should choose a single configured version",
     )
 
     asserts.equals(
         env,
         (None, ["0.4.0", "0.2.0", "0.1.0", "0.0.1"]),
-        handle_toolchain_tags(struct(
-            modules = [
+        handle_toolchain_tags(
+            [
                 struct(
                     is_root = False,
                     tags = struct(
@@ -71,15 +72,16 @@ def _zig_versions_test_impl(ctx):
                     ),
                 ),
             ],
-        ), known_versions = ["0.4.0", "0.2.0", "0.1.0", "0.0.1"]),
+            known_versions = ["0.4.0", "0.2.0", "0.1.0", "0.0.1"],
+        ),
         "should order versions by semver",
     )
 
     asserts.equals(
         env,
         (None, ["0.1.0", "0.0.1"]),
-        handle_toolchain_tags(struct(
-            modules = [
+        handle_toolchain_tags(
+            [
                 struct(
                     is_root = False,
                     tags = struct(
@@ -111,15 +113,16 @@ def _zig_versions_test_impl(ctx):
                     ),
                 ),
             ],
-        ), known_versions = ["0.1.0", "0.0.1"]),
+            known_versions = ["0.1.0", "0.0.1"],
+        ),
         "should deduplicate versions",
     )
 
     asserts.equals(
         env,
         (None, ["0.1.0", "0.4.0", "0.2.0", "0.0.1"]),
-        handle_toolchain_tags(struct(
-            modules = [
+        handle_toolchain_tags(
+            [
                 struct(
                     is_root = False,
                     tags = struct(
@@ -151,15 +154,16 @@ def _zig_versions_test_impl(ctx):
                     ),
                 ),
             ],
-        ), known_versions = ["0.4.0", "0.2.0", "0.1.0", "0.0.1"]),
+            known_versions = ["0.4.0", "0.2.0", "0.1.0", "0.0.1"],
+        ),
         "the default should take precedence",
     )
 
     asserts.equals(
         env,
         (None, ["0.1.0", "0.2.0", "0.0.1"]),
-        handle_toolchain_tags(struct(
-            modules = [
+        handle_toolchain_tags(
+            [
                 struct(
                     is_root = False,
                     tags = struct(
@@ -191,7 +195,8 @@ def _zig_versions_test_impl(ctx):
                     ),
                 ),
             ],
-        ), known_versions = ["0.2.0", "0.1.0", "0.0.1"]),
+            known_versions = ["0.2.0", "0.1.0", "0.0.1"],
+        ),
         "should not duplicate default",
     )
 
@@ -201,8 +206,8 @@ def _zig_versions_test_impl(ctx):
             default = True,
             zig_version = "0.1.0",
         )], None),
-        handle_toolchain_tags(struct(
-            modules = [
+        handle_toolchain_tags(
+            [
                 struct(
                     is_root = False,
                     tags = struct(
@@ -215,7 +220,8 @@ def _zig_versions_test_impl(ctx):
                     ),
                 ),
             ],
-        ), known_versions = ["0.1.0"]),
+            known_versions = ["0.1.0"],
+        ),
         "only root may set default",
     )
 
@@ -225,8 +231,8 @@ def _zig_versions_test_impl(ctx):
             default = True,
             zig_version = "0.2.0",
         )], None),
-        handle_toolchain_tags(struct(
-            modules = [
+        handle_toolchain_tags(
+            [
                 struct(
                     is_root = True,
                     tags = struct(
@@ -243,7 +249,8 @@ def _zig_versions_test_impl(ctx):
                     ),
                 ),
             ],
-        ), known_versions = ["0.2.0", "0.1.0"]),
+            known_versions = ["0.2.0", "0.1.0"],
+        ),
         "only one default allowed",
     )
 

--- a/zig/tests/bzlmod_zig_test.bzl
+++ b/zig/tests/bzlmod_zig_test.bzl
@@ -205,7 +205,7 @@ def _parse_zig_index_test_impl(ctx):
   }
 }
 """
-    expected_err = "Malformed version number in Zig SDK version index."
+    expected_err = "Malformed version number 'bad-version' in Zig SDK version index."
     result = parse_zig_versions_json(content)
     asserts.equals(env, (expected_err, None), result)
 

--- a/zig/tests/bzlmod_zig_test.bzl
+++ b/zig/tests/bzlmod_zig_test.bzl
@@ -78,6 +78,29 @@ def _parse_zig_index_test_impl(ctx):
     result = parse_zig_versions_json(content)
     asserts.equals(env, (None, expected), result)
 
+    content = """\
+{
+  "master": {
+    "version": "0.13.0-dev.46+3648d7df1",
+    "x86_64-macos": {
+      "tarball": "https://ziglang.org/builds/zig-macos-x86_64-0.13.0-dev.46+3648d7df1.tar.xz",
+      "shasum": "d8fb090bd69d7e191a3443520da5c52da430fbffc0de12ac87a114a6cc1f20ca",
+      "size": "47206948"
+    }
+  }
+}
+"""
+    expected = {
+        "0.13.0-dev.46+3648d7df1": {
+            "x86_64-macos": struct(
+                url = "https://ziglang.org/builds/zig-macos-x86_64-0.13.0-dev.46+3648d7df1.tar.xz",
+                sha256 = "d8fb090bd69d7e191a3443520da5c52da430fbffc0de12ac87a114a6cc1f20ca",
+            ),
+        },
+    }
+    result = parse_zig_versions_json(content)
+    asserts.equals(env, (None, expected), result)
+
     content = ""
     expected_err = "Invalid JSON format in Zig SDK version index."
     result = parse_zig_versions_json(content)

--- a/zig/tests/integration_tests/BUILD.bazel
+++ b/zig/tests/integration_tests/BUILD.bazel
@@ -91,7 +91,7 @@ zig_test(
 
 bazel_integration_test(
     name = "zig_version_tests",
-    size = "small",
+    size = "medium",
     bazel_version = bazel_binaries.versions.current,
     tags = ["requires-network"] + integration_test_utils.DEFAULT_INTEGRATION_TEST_TAGS,
     test_runner = ":zig_version_tests_runner",

--- a/zig/tests/integration_tests/BUILD.bazel
+++ b/zig/tests/integration_tests/BUILD.bazel
@@ -49,6 +49,10 @@ bazel_integration_tests(
     workspace_path = "workspace",
 )
 
+TEST_VERSIONS = TOOL_VERSIONS.keys() + [
+    "0.13.0-dev.46+3648d7df1",
+]
+
 [
     expand_template(
         name = "zig_version_test_%s_zig_source" % zig_version,
@@ -58,7 +62,7 @@ bazel_integration_tests(
         },
         template = "zig_version_test.zig.tpl",
     )
-    for zig_version in TOOL_VERSIONS.keys()
+    for zig_version in TEST_VERSIONS
 ]
 
 write_file(
@@ -68,7 +72,7 @@ write_file(
         "test {",
     ] + [
         '    _ = @import("zig_version_test_%s.zig");' % zig_version
-        for zig_version in TOOL_VERSIONS.keys()
+        for zig_version in TEST_VERSIONS
     ] + [
         "}",
     ],
@@ -78,7 +82,7 @@ zig_test(
     name = "zig_version_tests_runner",
     srcs = [
         "zig_version_test_%s.zig" % zig_version
-        for zig_version in TOOL_VERSIONS.keys()
+        for zig_version in TEST_VERSIONS
     ],
     main = "zig_version_tests_runner.zig",
     tags = ["manual"],

--- a/zig/tests/integration_tests/workspace/MODULE.bazel
+++ b/zig/tests/integration_tests/workspace/MODULE.bazel
@@ -7,6 +7,11 @@ local_path_override(
 )
 
 zig = use_extension("@rules_zig//zig:extensions.bzl", "zig")
-zig.toolchain(zig_version = "0.12.0")
+zig.index(file = "extra-versions.json")
+zig.toolchain(zig_version = "0.13.0-dev.46+3648d7df1")
+zig.toolchain(
+    default = True,
+    zig_version = "0.12.0",
+)
 zig.toolchain(zig_version = "0.11.0")
 use_repo(zig, "zig_toolchains")

--- a/zig/tests/integration_tests/workspace/extra-versions.json
+++ b/zig/tests/integration_tests/workspace/extra-versions.json
@@ -1,0 +1,73 @@
+{
+  "master": {
+    "version": "0.13.0-dev.46+3648d7df1",
+    "date": "2024-04-26",
+    "docs": "https://ziglang.org/documentation/master/",
+    "stdDocs": "https://ziglang.org/documentation/master/std/",
+    "src": {
+      "tarball": "https://ziglang.org/builds/zig-0.13.0-dev.46+3648d7df1.tar.xz",
+      "shasum": "08190cb4482be355acaecaae9d7936e4fad47180c97ca8138b97a122a313cd99",
+      "size": "17111524"
+    },
+    "bootstrap": {
+      "tarball": "https://ziglang.org/builds/zig-bootstrap-0.13.0-dev.46+3648d7df1.tar.xz",
+      "shasum": "78569b44dbfb8ec0cddbd1fa69ce398b973bd05c7f3b87f070cc2a0ba9c86571",
+      "size": "45555796"
+    },
+    "x86_64-macos": {
+      "tarball": "https://ziglang.org/builds/zig-macos-x86_64-0.13.0-dev.46+3648d7df1.tar.xz",
+      "shasum": "d8fb090bd69d7e191a3443520da5c52da430fbffc0de12ac87a114a6cc1f20ca",
+      "size": "47206948"
+    },
+    "aarch64-macos": {
+      "tarball": "https://ziglang.org/builds/zig-macos-aarch64-0.13.0-dev.46+3648d7df1.tar.xz",
+      "shasum": "37784926f45e5aba87f72f19de704adcb30604871df0c3ef6c0d177ae84bb741",
+      "size": "43466292"
+    },
+    "x86_64-linux": {
+      "tarball": "https://ziglang.org/builds/zig-linux-x86_64-0.13.0-dev.46+3648d7df1.tar.xz",
+      "shasum": "746e1102a6452722d382252cc6aed8728c7389ea16431bf5bc5ba0adc0f7e524",
+      "size": "45513200"
+    },
+    "aarch64-linux": {
+      "tarball": "https://ziglang.org/builds/zig-linux-aarch64-0.13.0-dev.46+3648d7df1.tar.xz",
+      "shasum": "b18710c4b62663be0b31aac80ef6916bf6763070e5fe3201ee273f033d828a70",
+      "size": "41880840"
+    },
+    "armv7a-linux": {
+      "tarball": "https://ziglang.org/builds/zig-linux-armv7a-0.13.0-dev.46+3648d7df1.tar.xz",
+      "shasum": "a5f20e3cdbe8b3d88c83d6ac7a3739f18ba7d2c5f20c31c5d3a765427593be48",
+      "size": "42686280"
+    },
+    "riscv64-linux": {
+      "tarball": "https://ziglang.org/builds/zig-linux-riscv64-0.13.0-dev.46+3648d7df1.tar.xz",
+      "shasum": "e41ea9b6cfa9c653614ffeee77e7ae1212201dfabdb02bd70aad191232947da1",
+      "size": "43932784"
+    },
+    "powerpc64le-linux": {
+      "tarball": "https://ziglang.org/builds/zig-linux-powerpc64le-0.13.0-dev.46+3648d7df1.tar.xz",
+      "shasum": "611edc13d17a26a0f6ca6723bd86e0bb28270415fadfcafaebd03240ae649e0a",
+      "size": "45260476"
+    },
+    "x86-linux": {
+      "tarball": "https://ziglang.org/builds/zig-linux-x86-0.13.0-dev.46+3648d7df1.tar.xz",
+      "shasum": "f078dc7cf4610149a5e444a1e3bec9d336b6d09c44310969d3111638b784a754",
+      "size": "50565396"
+    },
+    "x86_64-windows": {
+      "tarball": "https://ziglang.org/builds/zig-windows-x86_64-0.13.0-dev.46+3648d7df1.zip",
+      "shasum": "7c76330891cc1283151defede948b67a568920dfde3a723a64a101c5e67d68ed",
+      "size": "77031600"
+    },
+    "aarch64-windows": {
+      "tarball": "https://ziglang.org/builds/zig-windows-aarch64-0.13.0-dev.46+3648d7df1.zip",
+      "shasum": "fc8541916e36f4a767b6661c72473399bf5e32481d5ac5ab29b385992c770b34",
+      "size": "73556923"
+    },
+    "x86-windows": {
+      "tarball": "https://ziglang.org/builds/zig-windows-x86-0.13.0-dev.46+3648d7df1.zip",
+      "shasum": "f32665b9763f7a862a72bc1833ca35e284ae73b5055ff57e22abad21c8e8beb5",
+      "size": "81538193"
+    }
+  }
+}


### PR DESCRIPTION
Depends on #291

Closes #76

To register a nightly toolchain a user must add a version index JSON file (as a available on https://ziglang.org/download/index.json) to their project, register it using the `zig.index(file = ...)` tag, and then register the version using `zig.toolchain(zig_version = ...)`.

This also provides support for the broader interpretation of #72.

- **Add the zig.index tag.**
- **Add doc string for the zig.toolchain tag**
- **handle_tags --> handle_toolchain_tags**
- **refactor: handle_toolchain_tags takes module list**
- **docs: update generated API docs**
- **feat: Support user defined Zig version index files**
- **Support JSON parsing error reporting**
- **Test Zig version index parsing**
- **Test JSON parsing failure cases**
- **Parse nightly version**
- **Test full index format parsing**
- **Filter out unknown platforms**
- **Test for bad version numbers**
- **Validate version numbers**
- **Test version spec merging**
- **Integration test for extra versions index**
- **adjust test size**
- **docs: specify default as latest known version**
