### PR TITLE
chore!: drop Bazel 6 support

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -47,13 +47,13 @@ bazel_binaries = use_extension(
 
 # NOTE: Keep in sync with WORKSPACE.
 bazel_binaries.download(version_file = "//:.bazelversion")
-bazel_binaries.download(version = "6.3.0")
+bazel_binaries.download(version = "7.0.0")
 use_repo(
     bazel_binaries,
     "bazel_binaries",
     "bazel_binaries_bazelisk",
     "build_bazel_bazel_.bazelversion",
-    "build_bazel_bazel_6_3_0",
+    "build_bazel_bazel_7_0_0",
 )
 
 # TODO[AH] Should be an implicit transitive dependency through rules_bazel_integration_test.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Consider the [_Additional Setup_](#additional-setup) section as well.
 
 [bazel-intro]: https://bazel.build/about/intro
 
-### Using Bzlmod with Bazel >=6
+### Using Bzlmod with Bazel >=7
 
 Bzlmod is Bazel's new dependency manager. You can read more about it in the
 [Bazel documentation][bzlmod-doc]. If you use bzlmod, then you can skip the

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -55,7 +55,7 @@ load("@rules_bazel_integration_test//bazel_integration_test:defs.bzl", "bazel_bi
 # NOTE: Keep in sync with MODULE.bazel.
 bazel_binaries(versions = [
     "//:.bazelversion",
-    "6.3.0",
+    "7.0.0",
 ])
 
 # Stardoc dependencies


### PR DESCRIPTION
This is required for #290, which needs `json.decode(..., default=...)`, i.e. the `default` argument to `json.decode`. Unfortunately, that feature is not represented in https://github.com/bazel-contrib/bazel_features, so there is also no good way to check for the availability of this feature.

- **chore!: drop Bazel 6 support**
- **docs: Update README**

BREAKING CHANGE: Bazel versions <7 are no longer supported
