### PR TITLE
chore: update .bazelrc configuratio

### DIFF
--- a/.bazelrc.common
+++ b/.bazelrc.common
@@ -20,10 +20,6 @@ build --sandbox_default_allow_network=false
 # docs: https://bazel.build/reference/command-line-reference#flag--legacy_external_runfiles
 build --nolegacy_external_runfiles
 
-# Bazel 7 enables this by default. However, it causes failures with rules_bazel_integration_test.
-# docs: https://bazel.build/reference/command-line-reference#flag--incompatible_sandbox_hermetic_tmp
-build --noincompatible_sandbox_hermetic_tmp
-
 # docs: https://bazel.build/reference/command-line-reference#flag--test_output
 test --test_output=errors
 # docs: https://bazel.build/reference/command-line-reference#flag--test_verbose_timeout_warnings

--- a/.bazelrc.flags
+++ b/.bazelrc.flags
@@ -3,5 +3,6 @@
 # Copy this file into your project and import it into your `.bazelrc` to enable
 # the same aliases.
 
+build --flag_alias=zig_version=@zig_toolchains//:version
 build --flag_alias=zig_mode=@rules_zig//zig/settings:mode
 build --flag_alias=zig_threaded=@rules_zig//zig/settings:threaded

--- a/.bazelrc.remote
+++ b/.bazelrc.remote
@@ -3,7 +3,7 @@
 # docs: https://bazel.build/reference/command-line-reference#flag--bes_results_url
 build --bes_results_url=https://app.buildbuddy.io/invocation/
 # docs: https://bazel.build/reference/command-line-reference#flag--remote_build_event_upload
-build --experimental_remote_build_event_upload=minimal
+build --remote_build_event_upload=minimal
 # docs: https://bazel.build/reference/command-line-reference#flag--slim_profile
 build --noslim_profile
 # docs: https://bazel.build/reference/command-line-reference#flag--experimental_profile_include_target_label

--- a/.bazelrc.remote
+++ b/.bazelrc.remote
@@ -21,7 +21,7 @@ build --bes_backend=grpcs://remote.buildbuddy.io
 # docs: https://bazel.build/reference/command-line-reference#flag--remote_cache
 build --remote_cache=grpcs://remote.buildbuddy.io
 # docs: https://bazel.build/reference/command-line-reference#flag--remote_cache_compression
-build --experimental_remote_cache_compression
+build --remote_cache_compression
 # docs: https://bazel.build/reference/command-line-reference#flag--remote_download_toplevel
 build --remote_download_toplevel
 # docs: https://bazel.build/reference/command-line-reference#flag--remote_timeout

--- a/.bazelrc.remote
+++ b/.bazelrc.remote
@@ -1,7 +1,5 @@
 # Build event stream setup.
 
-# docs: https://bazel.build/reference/command-line-reference#flag--bes_results_url
-build --bes_results_url=https://app.buildbuddy.io/invocation/
 # docs: https://bazel.build/reference/command-line-reference#flag--remote_build_event_upload
 build --remote_build_event_upload=minimal
 # docs: https://bazel.build/reference/command-line-reference#flag--slim_profile
@@ -12,6 +10,9 @@ build --experimental_profile_include_target_label
 build --experimental_profile_include_primary_output
 # docs: https://bazel.build/reference/command-line-reference#flag--legacy_important_outputs
 build --nolegacy_important_outputs
+
+# docs: https://bazel.build/reference/command-line-reference#flag--bes_results_url
+build --bes_results_url=https://app.buildbuddy.io/invocation/
 # docs: https://bazel.build/reference/command-line-reference#flag--bes_backend
 build --bes_backend=grpcs://remote.buildbuddy.io
 


### PR DESCRIPTION
With Bazel 6 support dropped some experimental flags can be replaced by their non-experimental versions. 

- **Redundant --noincompatible_sandbox_hermetic_tmp**
- **Add --zig_version flag alias**
- **Replace --experimental_remote_build_event_upload**
- **Sort --bes_* flags**
- **Replace --experimental_remote_cache_compression**
