### PR TITLE
chore!: enable remote execution on CI for Linux

### DIFF
--- a/.bazelrc.remote
+++ b/.bazelrc.remote
@@ -34,3 +34,8 @@ build --remote_executor=grpcs://remote.buildbuddy.io
 
 # docs: https://bazel.build/reference/command-line-reference#flag--jobs
 build --jobs=80
+
+# docs: https://bazel.build/reference/command-line-reference#flag--extra_execution_platforms
+build --extra_execution_platforms=@buildbuddy_toolchain//:platform
+# docs: https://bazel.build/reference/command-line-reference#flag--extra_toolchains
+build --extra_toolchains=@buildbuddy_toolchain//:cc_toolchain

--- a/.bazelrc.remote
+++ b/.bazelrc.remote
@@ -1,41 +1,43 @@
+build:remote --config=remote-bes --config=remote-cache --config=remote-exec
+
 # Build event stream setup.
 
 # docs: https://bazel.build/reference/command-line-reference#flag--remote_build_event_upload
-build --remote_build_event_upload=minimal
+build:remote-bes --remote_build_event_upload=minimal
 # docs: https://bazel.build/reference/command-line-reference#flag--slim_profile
-build --noslim_profile
+build:remote-bes --noslim_profile
 # docs: https://bazel.build/reference/command-line-reference#flag--experimental_profile_include_target_label
-build --experimental_profile_include_target_label
+build:remote-bes --experimental_profile_include_target_label
 # docs: https://bazel.build/reference/command-line-reference#flag--experimental_profile_include_primary_output
-build --experimental_profile_include_primary_output
+build:remote-bes --experimental_profile_include_primary_output
 # docs: https://bazel.build/reference/command-line-reference#flag--legacy_important_outputs
-build --nolegacy_important_outputs
+build:remote-bes --nolegacy_important_outputs
 
 # docs: https://bazel.build/reference/command-line-reference#flag--bes_results_url
-build --bes_results_url=https://app.buildbuddy.io/invocation/
+build:remote-bes --bes_results_url=https://app.buildbuddy.io/invocation/
 # docs: https://bazel.build/reference/command-line-reference#flag--bes_backend
-build --bes_backend=grpcs://remote.buildbuddy.io
+build:remote-bes --bes_backend=grpcs://remote.buildbuddy.io
 
 # Remote cache setup.
 
 # docs: https://bazel.build/reference/command-line-reference#flag--remote_cache
-build --remote_cache=grpcs://remote.buildbuddy.io
+build:remote-cache --remote_cache=grpcs://remote.buildbuddy.io
 # docs: https://bazel.build/reference/command-line-reference#flag--remote_cache_compression
-build --remote_cache_compression
+build:remote-cache --remote_cache_compression
 # docs: https://bazel.build/reference/command-line-reference#flag--remote_download_toplevel
-build --remote_download_toplevel
+build:remote-cache --remote_download_toplevel
 # docs: https://bazel.build/reference/command-line-reference#flag--remote_timeout
-build --remote_timeout=3600
+build:remote-cache --remote_timeout=3600
 
 # Remote execution setup.
 
 # docs: https://bazel.build/reference/command-line-reference#flag--remote_executor
-build --remote_executor=grpcs://remote.buildbuddy.io
+build:remote-exec --remote_executor=grpcs://remote.buildbuddy.io
 
 # docs: https://bazel.build/reference/command-line-reference#flag--jobs
-build --jobs=80
+build:remote-exec --jobs=80
 
 # docs: https://bazel.build/reference/command-line-reference#flag--extra_execution_platforms
-build --extra_execution_platforms=@buildbuddy_toolchain//:platform
+build:remote-exec --extra_execution_platforms=@buildbuddy_toolchain//:platform
 # docs: https://bazel.build/reference/command-line-reference#flag--extra_toolchains
-build --extra_toolchains=@buildbuddy_toolchain//:cc_toolchain
+build:remote-exec --extra_toolchains=@buildbuddy_toolchain//:cc_toolchain

--- a/.bazelrc.remote
+++ b/.bazelrc.remote
@@ -27,4 +27,7 @@ build --remote_download_toplevel
 # docs: https://bazel.build/reference/command-line-reference#flag--remote_timeout
 build --remote_timeout=3600
 
+# Remote execution setup.
 
+# docs: https://bazel.build/reference/command-line-reference#flag--remote_executor
+build --remote_executor=grpcs://remote.buildbuddy.io

--- a/.bazelrc.remote
+++ b/.bazelrc.remote
@@ -31,3 +31,6 @@ build --remote_timeout=3600
 
 # docs: https://bazel.build/reference/command-line-reference#flag--remote_executor
 build --remote_executor=grpcs://remote.buildbuddy.io
+
+# docs: https://bazel.build/reference/command-line-reference#flag--jobs
+build --jobs=80

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -170,7 +170,12 @@ jobs:
 
       - name: Configure remote cache and execution
         working-directory: ${{ matrix.folder }}
-        run: echo "build --config=remote" >> .bazelrc.user
+        run: |
+          cat <<EOF >>.bazelrc.user
+          build --config=remote-bes --config=remote-cache
+          # Remote execution on non-Linux is only available for BuildBuddy Enterprise.
+          build:linux --config=remote
+          EOF
 
       - name: Configure Bazel version
         working-directory: ${{ matrix.folder }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -168,13 +168,17 @@ jobs:
           restore-keys: |
             bazel-cache-${{ matrix.os }}-${{ matrix.bazelversion }}-${{ matrix.bzlmodEnabled }}-${{ matrix.folder }}-${{ matrix.target }}
 
+      - name: Configure remote cache and execution
+        working-directory: ${{ matrix.folder }}
+        run: echo "build --config=remote" >> .bazelrc.user
+
       - name: Configure Bazel version
         working-directory: ${{ matrix.folder }}
         run: echo "USE_BAZEL_VERSION=${{ matrix.bazelversion }}" > .bazeliskrc
 
       - name: Configure Zig version
         working-directory: ${{ matrix.folder }}
-        run: echo "build --@zig_toolchains//:version=${{ matrix.zigversion }}" > .bazelrc.user
+        run: echo "build --@zig_toolchains//:version=${{ matrix.zigversion }}" >> .bazelrc.user
 
       - name: Configure documentation generation
         if: matrix.folder == '.' && matrix.target == '//...'

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -24,7 +24,6 @@ zig_dev = use_extension(
 zig_dev.toolchain(zig_version = "0.12.0")
 zig_dev.toolchain(zig_version = "0.11.0")
 
-bazel_dep(name = "hermetic_cc_toolchain", version = "3.0.1", dev_dependency = True)
 bazel_dep(name = "stardoc", version = "0.6.2", dev_dependency = True, repo_name = "io_bazel_stardoc")
 bazel_dep(name = "gazelle", version = "0.36.0", dev_dependency = True, repo_name = "bazel_gazelle")
 bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.6.1", dev_dependency = True)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -24,6 +24,7 @@ zig_dev = use_extension(
 zig_dev.toolchain(zig_version = "0.12.0")
 zig_dev.toolchain(zig_version = "0.11.0")
 
+bazel_dep(name = "rules_cc", version = "0.0.9", dev_dependency = True)
 bazel_dep(name = "stardoc", version = "0.6.2", dev_dependency = True, repo_name = "io_bazel_stardoc")
 bazel_dep(name = "gazelle", version = "0.36.0", dev_dependency = True, repo_name = "bazel_gazelle")
 bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.6.1", dev_dependency = True)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -24,6 +24,7 @@ zig_dev = use_extension(
 zig_dev.toolchain(zig_version = "0.12.0")
 zig_dev.toolchain(zig_version = "0.11.0")
 
+bazel_dep(name = "hermetic_cc_toolchain", version = "3.0.1", dev_dependency = True)
 bazel_dep(name = "stardoc", version = "0.6.2", dev_dependency = True, repo_name = "io_bazel_stardoc")
 bazel_dep(name = "gazelle", version = "0.36.0", dev_dependency = True, repo_name = "bazel_gazelle")
 bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.6.1", dev_dependency = True)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -22,6 +22,20 @@ zig_register_toolchains(
     zig_versions = TOOL_VERSIONS.keys(),
 )
 
+load("@hermetic_cc_toolchain//toolchain:defs.bzl", zig_cc_toolchains = "toolchains")
+
+zig_cc_toolchains()
+
+register_toolchains(
+    "@zig_sdk//toolchain:linux_amd64_gnu.2.28",
+    "@zig_sdk//toolchain:linux_arm64_gnu.2.28",
+    "@zig_sdk//toolchain:darwin_amd64",
+    "@zig_sdk//toolchain:darwin_arm64",
+    "@zig_sdk//toolchain:windows_amd64",
+    "@zig_sdk//toolchain:windows_arm64",
+    "@zig_sdk//toolchain:wasip1_wasm",
+)
+
 # rules_python dependencies
 load("@rules_python//python:repositories.bzl", "py_repositories")
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -22,20 +22,6 @@ zig_register_toolchains(
     zig_versions = TOOL_VERSIONS.keys(),
 )
 
-load("@hermetic_cc_toolchain//toolchain:defs.bzl", zig_cc_toolchains = "toolchains")
-
-zig_cc_toolchains()
-
-register_toolchains(
-    "@zig_sdk//toolchain:linux_amd64_gnu.2.28",
-    "@zig_sdk//toolchain:linux_arm64_gnu.2.28",
-    "@zig_sdk//toolchain:darwin_amd64",
-    "@zig_sdk//toolchain:darwin_arm64",
-    "@zig_sdk//toolchain:windows_amd64",
-    "@zig_sdk//toolchain:windows_arm64",
-    "@zig_sdk//toolchain:wasip1_wasm",
-)
-
 # rules_python dependencies
 load("@rules_python//python:repositories.bzl", "py_repositories")
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -22,6 +22,14 @@ zig_register_toolchains(
     zig_versions = TOOL_VERSIONS.keys(),
 )
 
+load("@io_buildbuddy_buildbuddy_toolchain//:deps.bzl", "buildbuddy_deps")
+
+buildbuddy_deps()
+
+load("@io_buildbuddy_buildbuddy_toolchain//:rules.bzl", "buildbuddy")
+
+buildbuddy(name = "buildbuddy_toolchain")
+
 # rules_python dependencies
 load("@rules_python//python:repositories.bzl", "py_repositories")
 

--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -1,0 +1,12 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "io_buildbuddy_buildbuddy_toolchain",
+    sha256 = "69f605320bed81fc11f1ab69bd76bd7199eca25c7d554504029c85b0a2ebb9af",
+    strip_prefix = "buildbuddy-toolchain-5bf0572e5a9c1e99fddb8e282e9a4cb6734ecd79",
+    urls = ["https://github.com/buildbuddy-io/buildbuddy-toolchain/archive/5bf0572e5a9c1e99fddb8e282e9a4cb6734ecd79.tar.gz"],
+)
+
+load("@io_buildbuddy_buildbuddy_toolchain//:rules.bzl", "buildbuddy")
+
+buildbuddy(name = "buildbuddy_toolchain")

--- a/e2e/workspace/MODULE.bazel
+++ b/e2e/workspace/MODULE.bazel
@@ -2,7 +2,6 @@ bazel_dep(name = "rules_zig", version = "0.0.0", dev_dependency = True)
 bazel_dep(name = "aspect_bazel_lib", version = "2.7.3", dev_dependency = True)
 bazel_dep(name = "bazel_skylib", version = "1.6.1", dev_dependency = True)
 bazel_dep(name = "platforms", version = "0.0.10", dev_dependency = True)
-bazel_dep(name = "hermetic_cc_toolchain", version = "3.0.1", dev_dependency = True)
 
 local_path_override(
     module_name = "rules_zig",

--- a/e2e/workspace/MODULE.bazel
+++ b/e2e/workspace/MODULE.bazel
@@ -2,6 +2,7 @@ bazel_dep(name = "rules_zig", version = "0.0.0", dev_dependency = True)
 bazel_dep(name = "aspect_bazel_lib", version = "2.7.3", dev_dependency = True)
 bazel_dep(name = "bazel_skylib", version = "1.6.1", dev_dependency = True)
 bazel_dep(name = "platforms", version = "0.0.10", dev_dependency = True)
+bazel_dep(name = "rules_cc", version = "0.0.9", dev_dependency = True)
 
 local_path_override(
     module_name = "rules_zig",

--- a/e2e/workspace/MODULE.bazel
+++ b/e2e/workspace/MODULE.bazel
@@ -2,6 +2,7 @@ bazel_dep(name = "rules_zig", version = "0.0.0", dev_dependency = True)
 bazel_dep(name = "aspect_bazel_lib", version = "2.7.3", dev_dependency = True)
 bazel_dep(name = "bazel_skylib", version = "1.6.1", dev_dependency = True)
 bazel_dep(name = "platforms", version = "0.0.10", dev_dependency = True)
+bazel_dep(name = "hermetic_cc_toolchain", version = "3.0.1", dev_dependency = True)
 
 local_path_override(
     module_name = "rules_zig",

--- a/e2e/workspace/WORKSPACE.bazel
+++ b/e2e/workspace/WORKSPACE.bazel
@@ -29,6 +29,21 @@ aspect_bazel_lib_dependencies()
 
 aspect_bazel_lib_register_toolchains()
 
+http_archive(
+    name = "io_buildbuddy_buildbuddy_toolchain",
+    sha256 = "69f605320bed81fc11f1ab69bd76bd7199eca25c7d554504029c85b0a2ebb9af",
+    strip_prefix = "buildbuddy-toolchain-5bf0572e5a9c1e99fddb8e282e9a4cb6734ecd79",
+    urls = ["https://github.com/buildbuddy-io/buildbuddy-toolchain/archive/5bf0572e5a9c1e99fddb8e282e9a4cb6734ecd79.tar.gz"],
+)
+
+load("@io_buildbuddy_buildbuddy_toolchain//:deps.bzl", "buildbuddy_deps")
+
+buildbuddy_deps()
+
+load("@io_buildbuddy_buildbuddy_toolchain//:rules.bzl", "buildbuddy")
+
+buildbuddy(name = "buildbuddy_toolchain")
+
 #---SNIP--- Below here is re-used in the workspace snippet published on releases
 
 ###################

--- a/e2e/workspace/WORKSPACE.bazel
+++ b/e2e/workspace/WORKSPACE.bazel
@@ -17,6 +17,29 @@ local_repository(
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
+    name = "hermetic_cc_toolchain",
+    sha256 = "3bc6ec127622fdceb4129cb06b6f7ab098c4d539124dde96a6318e7c32a53f7a",
+    urls = [
+        "https://mirror.bazel.build/github.com/uber/hermetic_cc_toolchain/releases/download/v3.0.1/hermetic_cc_toolchain-v3.0.1.tar.gz",
+        "https://github.com/uber/hermetic_cc_toolchain/releases/download/v3.0.1/hermetic_cc_toolchain-v3.0.1.tar.gz",
+    ],
+)
+
+load("@hermetic_cc_toolchain//toolchain:defs.bzl", zig_cc_toolchains = "toolchains")
+
+zig_cc_toolchains()
+
+register_toolchains(
+    "@zig_sdk//toolchain:linux_amd64_gnu.2.28",
+    "@zig_sdk//toolchain:linux_arm64_gnu.2.28",
+    "@zig_sdk//toolchain:darwin_amd64",
+    "@zig_sdk//toolchain:darwin_arm64",
+    "@zig_sdk//toolchain:windows_amd64",
+    "@zig_sdk//toolchain:windows_arm64",
+    "@zig_sdk//toolchain:wasip1_wasm",
+)
+
+http_archive(
     name = "aspect_bazel_lib",
     sha256 = "87ab4ec479ebeb00d286266aca2068caeef1bb0b1765e8f71c7b6cfee6af4226",
     strip_prefix = "bazel-lib-2.7.3",

--- a/e2e/workspace/WORKSPACE.bazel
+++ b/e2e/workspace/WORKSPACE.bazel
@@ -17,29 +17,6 @@ local_repository(
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
-    name = "hermetic_cc_toolchain",
-    sha256 = "3bc6ec127622fdceb4129cb06b6f7ab098c4d539124dde96a6318e7c32a53f7a",
-    urls = [
-        "https://mirror.bazel.build/github.com/uber/hermetic_cc_toolchain/releases/download/v3.0.1/hermetic_cc_toolchain-v3.0.1.tar.gz",
-        "https://github.com/uber/hermetic_cc_toolchain/releases/download/v3.0.1/hermetic_cc_toolchain-v3.0.1.tar.gz",
-    ],
-)
-
-load("@hermetic_cc_toolchain//toolchain:defs.bzl", zig_cc_toolchains = "toolchains")
-
-zig_cc_toolchains()
-
-register_toolchains(
-    "@zig_sdk//toolchain:linux_amd64_gnu.2.28",
-    "@zig_sdk//toolchain:linux_arm64_gnu.2.28",
-    "@zig_sdk//toolchain:darwin_amd64",
-    "@zig_sdk//toolchain:darwin_arm64",
-    "@zig_sdk//toolchain:windows_amd64",
-    "@zig_sdk//toolchain:windows_arm64",
-    "@zig_sdk//toolchain:wasip1_wasm",
-)
-
-http_archive(
     name = "aspect_bazel_lib",
     sha256 = "87ab4ec479ebeb00d286266aca2068caeef1bb0b1765e8f71c7b6cfee6af4226",
     strip_prefix = "bazel-lib-2.7.3",

--- a/e2e/workspace/WORKSPACE.bzlmod
+++ b/e2e/workspace/WORKSPACE.bzlmod
@@ -1,2 +1,15 @@
 # When --enable_bzlmod is set, this file replaces WORKSPACE.bazel.
 # Dependencies then come from MODULE.bazel instead.
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "io_buildbuddy_buildbuddy_toolchain",
+    sha256 = "69f605320bed81fc11f1ab69bd76bd7199eca25c7d554504029c85b0a2ebb9af",
+    strip_prefix = "buildbuddy-toolchain-5bf0572e5a9c1e99fddb8e282e9a4cb6734ecd79",
+    urls = ["https://github.com/buildbuddy-io/buildbuddy-toolchain/archive/5bf0572e5a9c1e99fddb8e282e9a4cb6734ecd79.tar.gz"],
+)
+
+load("@io_buildbuddy_buildbuddy_toolchain//:rules.bzl", "buildbuddy")
+
+buildbuddy(name = "buildbuddy_toolchain")

--- a/e2e/workspace/configure-mode/BUILD.bazel
+++ b/e2e/workspace/configure-mode/BUILD.bazel
@@ -33,7 +33,7 @@ genrule(
     name = "library_debug_symbol",
     srcs = [":library_debug"],
     outs = ["library_debug_symbol.txt"],
-    cmd = "$(NM) -j --defined-only $(SRCS) | grep Debug > $(OUTS)",
+    cmd = "$(NM) --defined-only $(SRCS) | grep Debug > $(OUTS)",
     toolchains = ["@bazel_tools//tools/cpp:current_cc_toolchain"],
 )
 
@@ -41,7 +41,7 @@ genrule(
     name = "library_release_safe_symbol",
     srcs = [":library_release_safe"],
     outs = ["library_release_safe_symbol.txt"],
-    cmd = "$(NM) -j --defined-only $(SRCS) | grep ReleaseSafe > $(OUTS)",
+    cmd = "$(NM) --defined-only $(SRCS) | grep ReleaseSafe > $(OUTS)",
     toolchains = ["@bazel_tools//tools/cpp:current_cc_toolchain"],
 )
 

--- a/e2e/workspace/configure-threaded/BUILD.bazel
+++ b/e2e/workspace/configure-threaded/BUILD.bazel
@@ -33,7 +33,7 @@ genrule(
     name = "library_single_symbol",
     srcs = [":library_single"],
     outs = ["library_single_symbol.txt"],
-    cmd = "$(NM) -j --defined-only $(SRCS) | grep single_threaded > $(OUTS)",
+    cmd = "$(NM) --defined-only $(SRCS) | grep single_threaded > $(OUTS)",
     toolchains = ["@bazel_tools//tools/cpp:current_cc_toolchain"],
 )
 
@@ -41,7 +41,7 @@ genrule(
     name = "library_multi_symbol",
     srcs = [":library_multi"],
     outs = ["library_multi_symbol.txt"],
-    cmd = "$(NM) -j --defined-only $(SRCS) | grep multi_threaded > $(OUTS)",
+    cmd = "$(NM) --defined-only $(SRCS) | grep multi_threaded > $(OUTS)",
     toolchains = ["@bazel_tools//tools/cpp:current_cc_toolchain"],
 )
 

--- a/e2e/workspace/link-dependencies/static-library/BUILD.bazel
+++ b/e2e/workspace/link-dependencies/static-library/BUILD.bazel
@@ -47,7 +47,7 @@ genrule(
     outs = ["library-symbol.txt"],
     # Test that `add` is not inlined into the Zig library, but remains an
     # undefined symbol to be resolved later.
-    cmd = "$(NM) -j --undefined-only $(SRCS) | grep add > $(OUTS)",
+    cmd = "$(NM) --undefined-only $(SRCS) | grep add > $(OUTS)",
     toolchains = ["@bazel_tools//tools/cpp:current_cc_toolchain"],
 )
 

--- a/e2e/workspace/simple-library/BUILD.bazel
+++ b/e2e/workspace/simple-library/BUILD.bazel
@@ -10,7 +10,7 @@ genrule(
     name = "library-symbol",
     srcs = [":library"],
     outs = ["library-symbol.txt"],
-    cmd = "$(NM) -j --defined-only $(SRCS) | grep sayHello > $(OUTS)",
+    cmd = "$(NM) --defined-only $(SRCS) | grep sayHello > $(OUTS)",
     toolchains = ["@bazel_tools//tools/cpp:current_cc_toolchain"],
 )
 

--- a/e2e/workspace/simple-shared-library/BUILD.bazel
+++ b/e2e/workspace/simple-shared-library/BUILD.bazel
@@ -10,7 +10,7 @@ genrule(
     name = "shared-symbol",
     srcs = [":shared"],
     outs = ["shared-symbol.txt"],
-    cmd = "$(NM) -j --defined-only $(SRCS) | grep sayHello > $(OUTS)",
+    cmd = "$(NM) --defined-only $(SRCS) | grep sayHello > $(OUTS)",
     toolchains = ["@bazel_tools//tools/cpp:current_cc_toolchain"],
 )
 

--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -88,12 +88,3 @@ def rules_zig_internal_deps():
             "https://github.com/bazel-contrib/rules_bazel_integration_test/releases/download/v0.23.0/rules_bazel_integration_test.v0.23.0.tar.gz",
         ],
     )
-
-    http_archive(
-        name = "hermetic_cc_toolchain",
-        sha256 = "3bc6ec127622fdceb4129cb06b6f7ab098c4d539124dde96a6318e7c32a53f7a",
-        urls = [
-            "https://mirror.bazel.build/github.com/uber/hermetic_cc_toolchain/releases/download/v3.0.1/hermetic_cc_toolchain-v3.0.1.tar.gz",
-            "https://github.com/uber/hermetic_cc_toolchain/releases/download/v3.0.1/hermetic_cc_toolchain-v3.0.1.tar.gz",
-        ],
-    )

--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -26,6 +26,13 @@ def rules_zig_internal_deps():
     )
 
     http_archive(
+        name = "io_buildbuddy_buildbuddy_toolchain",
+        sha256 = "69f605320bed81fc11f1ab69bd76bd7199eca25c7d554504029c85b0a2ebb9af",
+        strip_prefix = "buildbuddy-toolchain-5bf0572e5a9c1e99fddb8e282e9a4cb6734ecd79",
+        urls = ["https://github.com/buildbuddy-io/buildbuddy-toolchain/archive/5bf0572e5a9c1e99fddb8e282e9a4cb6734ecd79.tar.gz"],
+    )
+
+    http_archive(
         name = "rules_python",
         sha256 = "c68bdc4fbec25de5b5493b8819cfc877c4ea299c0dcb15c244c5a00208cde311",
         strip_prefix = "rules_python-0.31.0",

--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -88,3 +88,12 @@ def rules_zig_internal_deps():
             "https://github.com/bazel-contrib/rules_bazel_integration_test/releases/download/v0.23.0/rules_bazel_integration_test.v0.23.0.tar.gz",
         ],
     )
+
+    http_archive(
+        name = "hermetic_cc_toolchain",
+        sha256 = "3bc6ec127622fdceb4129cb06b6f7ab098c4d539124dde96a6318e7c32a53f7a",
+        urls = [
+            "https://mirror.bazel.build/github.com/uber/hermetic_cc_toolchain/releases/download/v3.0.1/hermetic_cc_toolchain-v3.0.1.tar.gz",
+            "https://github.com/uber/hermetic_cc_toolchain/releases/download/v3.0.1/hermetic_cc_toolchain-v3.0.1.tar.gz",
+        ],
+    )

--- a/util/BUILD.bazel
+++ b/util/BUILD.bazel
@@ -18,6 +18,7 @@ buildifier_test(
     lint_mode = "warn",
     mode = "diff",
     no_sandbox = True,
+    tags = ["no-remote-exec"],
     workspace = "//:WORKSPACE",
 )
 


### PR DESCRIPTION
- Enables remote execution on CI.
- Installs the BuildBuddy platform and toolchain as a dev-dependency required for C/C++ targets, primarily protoc.

- **Enable remote execution**
- **Configure hermetic_cc_toolchain**
- **Configure more concurrent jobs for RE**
- **Revert "Configure hermetic_cc_toolchain"**
- **Install and configure BuildBuddy toolchains**
- **Remove -j from nm invocations**
- **Tag buildifier_test as no-remote-exec**
- **Make remote configuration explicit**
- **Enable remote execution on CI**
