### PR TITLE
fix: load shared libraries from runfiles

### DIFF
--- a/zig/private/common/zig_docs.bzl
+++ b/zig/private/common/zig_docs.bzl
@@ -1,6 +1,5 @@
 """Zig documentation generation."""
 
-load("@bazel_skylib//lib:paths.bzl", "paths")
 load(
     "//zig/private/common:bazel_builtin.bzl",
     "bazel_builtin_module",
@@ -94,7 +93,7 @@ def zig_docs_impl(ctx, *, kind):
 
     zig_cdeps(
         cdeps = ctx.attr.cdeps,
-        output_dir = paths.join(ctx.bin_dir.path, ctx.label.package),
+        solib_parents = [],
         os = zigtargetinfo.triple.os,
         direct_inputs = direct_inputs,
         transitive_inputs = transitive_inputs,


### PR DESCRIPTION
Adds a RUNPATH to support loading shared libraries from runfiles trees when the entrypoint is executed from outside the runfiles tree, e.g. in `genrule` build actions.

This issue was previously dormant because the shared library is still available under an alternative RUNPATH in local execution.

Otherwise running dynamically linked binaries fails in remote execution setups with errors of the form:
```
bazel-out/k8-opt-exec-ST-74b705998179/bin/link-dependencies/shared-library/binary: error while loading shared libraries: libadd.so: cannot open shared object file: No such file or directory
```

The library `libadd.so` is part of the action inputs, but only under the runfiles tree next to `binary` in `binary.runfiles/_main/_solib_k8/...`.

See https://github.com/bazelbuild/bazel/blob/7.0.0/src/main/java/com/google/devtools/build/lib/rules/cpp/LibrariesToLinkCollector.java#L177 for further details on RUNPATHS calculation.
See #296.
