### PR TITLE
chore: refactor CI workflow

### DIFF
--- a/.github/actions/test/action.yaml
+++ b/.github/actions/test/action.yaml
@@ -1,0 +1,124 @@
+name: Run Tests
+description: Run all tests for a specific configuration.
+inputs:
+  os:
+    description: "The runer's operating system, used in cache keys."
+    required: true
+  folder:
+    description: "The folder to run builds and tests in."
+    required: true
+  bazelVersion:
+    description: "The Bazel version to run the build and tests with."
+    required: true
+  bzlmodEnabled:
+    description: "Whether to use bzlmod or the legacy WORKSPACE mode."
+    required: true
+  docsEnabled:
+    description: "Whether to build Stardoc documentation."
+    required: true
+  zigVersion:
+    description: "The default Zig version to use."
+    required: true
+  targetPattern:
+    description: "The Bazel build and test target pattern."
+    required: true
+runs:
+  using: composite
+  steps:
+    # Cache build and external artifacts so that the next ci build is incremental.
+    # Because github action caches cannot be updated after a build, we need to
+    # store the contents of each build in a unique cache key, then fall back to loading
+    # it on the next ci run. We use hashFiles(...) in the key and restore-keys- with
+    # the prefix to load the most recent cache for the branch on a cache miss. You
+    # should customize the contents of hashFiles to capture any bazel input sources,
+    # although this doesn't need to be perfect. If none of the input sources change
+    # then a cache hit will load an existing cache and bazel won't have to do any work.
+    # In the case of a cache miss, you want the fallback cache to contain most of the
+    # previously built artifacts to minimize build time. The more precise you are with
+    # hashFiles sources the less work bazel will have to do.
+    - name: Mount bazel caches
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cache/bazel
+          ~/.cache/bazel-repo
+        key: bazel-cache-${{ inputs.os }}-${{ inputs.zigVersion }}-${{ inputs.bazelVersion }}-${{ inputs.bzlmodEnabled }}-${{ inputs.folder }}-${{ inputs.targetPattern }}-${{ hashFiles('**/BUILD.bazel', '**/*.bzl', '**/*.zig', 'WORKSPACE', 'WORKSPACE.bzlmod', 'MODULE.bazel') }}
+        restore-keys: |
+          bazel-cache-${{ inputs.os }}-${{ inputs.zigVersion }}-${{ inputs.bazelVersion }}-${{ inputs.bzlmodEnabled }}-${{ inputs.folder }}-${{ inputs.targetPattern }}
+
+    - name: Configure remote cache and execution
+      working-directory: ${{ inputs.folder }}
+      shell: bash
+      run: |
+        cat <<EOF >>.bazelrc.user
+        build --config=remote-bes --config=remote-cache
+        # Remote execution on non-Linux is only available for BuildBuddy Enterprise.
+        build:linux --config=remote
+        EOF
+        cat <<EOF >>.bazelrc.ic.user
+        build --config=remote-bes --config=remote-cache
+        # Remote execution on non-Linux is only available for BuildBuddy Enterprise.
+        build:linux --config=remote
+        EOF
+
+    - name: Configure Bazel version
+      working-directory: ${{ inputs.folder }}
+      shell: bash
+      run: echo "USE_BAZEL_VERSION=${{ inputs.bazelVersion }}" > .bazeliskrc
+
+    - name: Set bzlmod flag
+      working-directory: ${{ inputs.folder }}
+      # Set --enable_bzlmod if bzlmodEnabled is true, else --noenable_bzlmod.
+      id: set_bzlmod_flag
+      shell: bash
+      run: |
+        echo "common ${{ inputs.bzlmodEnabled == true && '--enable_bzlmod' || '--noenable_bzlmod' }}" >> .bazelrc.user
+        echo "bzlmod_flag=${{ inputs.bzlmodEnabled == true && '--enable_bzlmod' || '--noenable_bzlmod' }}" >> $GITHUB_OUTPUT
+
+    - name: Configure documentation generation
+      if: inputs.folder == '.' && inputs.targetPattern == '//...'
+      working-directory: ${{ inputs.folder }}
+      shell: bash
+      run: |
+        PREFIX=${{ inputs.docsEnabled == true && '' || 'no' }}
+        echo "common --$PREFIX@rules_zig//docs:build_docs" >> .bazelrc.user
+
+    - name: Configure Zig version
+      working-directory: ${{ inputs.folder }}
+      shell: bash
+      run: echo "build --@zig_toolchains//:version=${{ inputs.zigVersion }}" >> .bazelrc.user
+
+    - name: Test generated files
+      if: inputs.folder == '.' && inputs.targetPattern == '//...'
+      working-directory: ${{ inputs.folder }}
+      shell: bash
+      run: |
+        # Bazelisk will download bazel to here, ensure it is cached between runs.
+        export XDG_CACHE_HOME="$HOME/.cache/bazel-repo"
+        bazel --bazelrc=$GITHUB_WORKSPACE/.github/workflows/ci.bazelrc --bazelrc=.bazelrc run //util:update
+        test -z $(git status --porcelain) || { echo "Update generated files using `bazel run //util:update`" >&2; git diff >&2; exit 1; }
+
+    - name: Check for test.sh
+      # Checks for the existence of test.sh in the folder. Downstream steps can use
+      # steps.has_test_sh.outputs.files_exists as a conditional.
+      id: has_test_sh
+      uses: andstor/file-existence-action@v3
+      with:
+        files: "${{ inputs.folder }}/test.sh"
+
+    - name: ./test.sh
+      # Run if there is a test.sh file in the folder
+      if: steps.has_test_sh.outputs.files_exists == 'true'
+      working-directory: ${{ inputs.folder }}
+      shell: bash
+      # Run the script potentially setting BZLMOD_FLAG=--enable_bzlmod. All test.sh
+      # scripts that run bazel directly should make use of this variable.
+      run: BZLMOD_FLAG=${{ steps.set_bzlmod_flag.outputs.bzlmod_flag }} ./test.sh
+
+    - name: bazel test ${{ inputs.targetPattern }}
+      working-directory: ${{ inputs.folder }}
+      shell: bash
+      run: |
+        # Bazelisk will download bazel to here, ensure it is cached between runs.
+        export XDG_CACHE_HOME="$HOME/.cache/bazel-repo"
+        bazel --bazelrc=$GITHUB_WORKSPACE/.github/workflows/ci.bazelrc --bazelrc=.bazelrc test ${{ inputs.targetPattern }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,12 +58,13 @@ jobs:
       # Sorted in descending semver order.
       zigversions: ${{ steps.versions_from_zig_versions_json.outputs.zigversions }}
 
-  test:
+  test-bazel-versions:
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}
 
     needs:
       - matrix-prep-bazelversion
+      - matrix-prep-zigversion
 
     # Run bazel test in each workspace with each version of Bazel supported
     strategy:
@@ -71,7 +72,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         bazelVersion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions) }}
-        zigVersion: [0.12.0]
+        zigVersion:
+          - ${{ fromJSON(needs.matrix-prep-zigversion.outputs.zigversions)[0] }}
         bzlmodEnabled: [true, false]
         folder:
           - "."
@@ -189,7 +191,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - matrix-prep-bazelversion
-      - test
+      - test-bazel-versions
     if: ${{ always() }}
     steps:
       - uses: cgrindel/gha_join_jobs@v1.2.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,28 @@ jobs:
       # Will look like ["<version from .bazelversion>","<version from bazel_versions.bzl>"]
       bazelversions: ${{ steps.versions_from_bazel_versions_bzl.outputs.bazelversions }}
 
+  matrix-prep-zigversion:
+    # Prepares the 'zigversion' axis of the test matrix
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - id: versions_from_zig_versions_json
+        run: |
+          # https://stackoverflow.com/a/75770668/841562 by tlwhitec
+          # license https://creativecommons.org/licenses/by-sa/4.0/
+          jq_semver_cmp='
+            def opt(f):
+                . as $in | try f catch $in;
+            def semver_cmp:
+                sub("\\+.*$"; "")
+              | capture("^(?<v>[^-]+)(?:-(?<p>.*))?$") | [.v, .p // empty]
+              | map(split(".") | map(opt(tonumber)))
+              | .[1] |= (. // {});'
+          echo "zigversions=$(jq -c "$jq_semver_cmp"'keys|sort_by(semver_cmp)|reverse' zig/private/versions.json)" >> $GITHUB_OUTPUT
+    outputs:
+      # Sorted in descending semver order.
+      zigversions: ${{ steps.versions_from_zig_versions_json.outputs.zigversions }}
+
   test:
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,68 +100,52 @@ jobs:
             bzlmodEnabled: true
             folder: "."
             targetPattern: "//zig/tests/integration_tests"
-          # Only test older Zig versions with the latest Bazel version
-          - os: ubuntu-latest
-            bazelVersion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
-            zigVersion: 0.11.0
-            bzlmodEnabled: false
-            folder: "."
-            targetPattern: "//..."
-          - os: ubuntu-latest
-            bazelVersion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
-            zigVersion: 0.11.0
-            bzlmodEnabled: true
-            folder: "."
-            targetPattern: "//..."
-          - os: macos-latest
-            bazelVersion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
-            zigVersion: 0.11.0
-            bzlmodEnabled: true
-            folder: "."
-            targetPattern: "//..."
-          - os: ubuntu-latest
-            bazelVersion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
-            zigVersion: 0.11.0
-            bzlmodEnabled: false
-            folder: "e2e/workspace"
-            targetPattern: "//..."
-          - os: ubuntu-latest
-            bazelVersion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
-            zigVersion: 0.11.0
-            bzlmodEnabled: true
-            folder: "e2e/workspace"
-            targetPattern: "//..."
-          - os: macos-latest
-            bazelVersion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
-            zigVersion: 0.11.0
-            bzlmodEnabled: true
-            folder: "e2e/workspace"
-            targetPattern: "//..."
-          # Only test the latest Bazel version on MacOS (MacOS runners are expensive and slow)
-          - os: macos-latest
-            bazelVersion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
-            zigVersion: 0.12.0
-            bzlmodEnabled: false
-            folder: "."
-            targetPattern: "//..."
-          - os: macos-latest
-            bazelVersion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
-            zigVersion: 0.12.0
-            bzlmodEnabled: true
-            folder: "."
-            targetPattern: "//..."
-          - os: macos-latest
-            bazelVersion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
-            zigVersion: 0.12.0
-            bzlmodEnabled: false
-            folder: "e2e/workspace"
-            targetPattern: "//..."
-          - os: macos-latest
-            bazelVersion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
-            zigVersion: 0.12.0
-            bzlmodEnabled: true
-            folder: "e2e/workspace"
-            targetPattern: "//..."
+
+    # Configure a human readable name for each job
+    name: Test ${{ matrix.targetPattern }} in ${{ matrix.folder }} with Zig ${{ matrix.zigVersion }}, Bazel ${{ matrix.bazelVersion }}, and bzlmod ${{ matrix.bzlmodEnabled }} on ${{ matrix.os }}
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/test
+        with:
+          os: ${{ matrix.os }}
+          folder: ${{ matrix.folder }}
+          bazelVersion: ${{ matrix.bazelVersion }}
+          bzlmodEnabled: ${{ matrix.bzlmodEnabled }}
+          # Disable documentation generation for all but the first Bazel
+          # version, by setting --no@rules_zig//docs:build_docs in
+          # .bazelrc.user. The generated documentation can vary between Bazel
+          # versions. For example, Bazel version 7 changed the documentation of
+          # the implicit `repo_mapping` parameter to repository rules compared
+          # to Bazel version 6.
+          docsEnabled: ${{ matrix.bazelVersion == fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
+          zigVersion: ${{ matrix.zigVersion }}
+          targetPattern: ${{ matrix.targetPattern }}
+
+  test-zig-versions:
+    # The type of runner that the job will run on
+    runs-on: ${{ matrix.os }}
+
+    needs:
+      - matrix-prep-bazelversion
+      - matrix-prep-zigversion
+
+    # Run bazel test in each workspace with each version of Bazel supported
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        bazelVersion:
+          - ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
+        zigVersion: ${{ fromJSON(needs.matrix-prep-zigversion.outputs.zigversions) }}
+        bzlmodEnabled: [true, false]
+        folder:
+          - "."
+          - "e2e/workspace"
+        targetPattern: ["//..."]
 
     # Configure a human readable name for each job
     name: Test ${{ matrix.targetPattern }} in ${{ matrix.folder }} with Zig ${{ matrix.zigVersion }}, Bazel ${{ matrix.bazelVersion }}, and bzlmod ${{ matrix.bzlmodEnabled }} on ${{ matrix.os }}
@@ -192,6 +176,7 @@ jobs:
     needs:
       - matrix-prep-bazelversion
       - test-bazel-versions
+      - test-zig-versions
     if: ${{ always() }}
     steps:
       - uses: cgrindel/gha_join_jobs@v1.2.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,99 +48,99 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        bazelversion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions) }}
-        zigversion: [0.12.0]
+        bazelVersion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions) }}
+        zigVersion: [0.12.0]
         bzlmodEnabled: [true, false]
         folder:
           - "."
           - "e2e/workspace"
-        target: ["//..."]
+        targetPattern: ["//..."]
         include:
           # The integration tests iterate over all supported Bazel versions, so
           # we only run them against the latest Bazel version.
           - os: ubuntu-latest
-            bazelversion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
-            zigversion: 0.12.0
+            bazelVersion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
+            zigVersion: 0.12.0
             bzlmodEnabled: false
             folder: "."
-            target: "//zig/tests/integration_tests"
+            targetPattern: "//zig/tests/integration_tests"
           - os: ubuntu-latest
-            bazelversion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
-            zigversion: 0.12.0
+            bazelVersion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
+            zigVersion: 0.12.0
             bzlmodEnabled: true
             folder: "."
-            target: "//zig/tests/integration_tests"
+            targetPattern: "//zig/tests/integration_tests"
           - os: macos-latest
-            bazelversion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
-            zigversion: 0.12.0
+            bazelVersion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
+            zigVersion: 0.12.0
             bzlmodEnabled: true
             folder: "."
-            target: "//zig/tests/integration_tests"
+            targetPattern: "//zig/tests/integration_tests"
           # Only test older Zig versions with the latest Bazel version
           - os: ubuntu-latest
-            bazelversion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
-            zigversion: 0.11.0
+            bazelVersion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
+            zigVersion: 0.11.0
             bzlmodEnabled: false
             folder: "."
-            target: "//..."
+            targetPattern: "//..."
           - os: ubuntu-latest
-            bazelversion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
-            zigversion: 0.11.0
+            bazelVersion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
+            zigVersion: 0.11.0
             bzlmodEnabled: true
             folder: "."
-            target: "//..."
+            targetPattern: "//..."
           - os: macos-latest
-            bazelversion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
-            zigversion: 0.11.0
+            bazelVersion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
+            zigVersion: 0.11.0
             bzlmodEnabled: true
             folder: "."
-            target: "//..."
+            targetPattern: "//..."
           - os: ubuntu-latest
-            bazelversion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
-            zigversion: 0.11.0
+            bazelVersion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
+            zigVersion: 0.11.0
             bzlmodEnabled: false
             folder: "e2e/workspace"
-            target: "//..."
+            targetPattern: "//..."
           - os: ubuntu-latest
-            bazelversion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
-            zigversion: 0.11.0
+            bazelVersion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
+            zigVersion: 0.11.0
             bzlmodEnabled: true
             folder: "e2e/workspace"
-            target: "//..."
+            targetPattern: "//..."
           - os: macos-latest
-            bazelversion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
-            zigversion: 0.11.0
+            bazelVersion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
+            zigVersion: 0.11.0
             bzlmodEnabled: true
             folder: "e2e/workspace"
-            target: "//..."
+            targetPattern: "//..."
           # Only test the latest Bazel version on MacOS (MacOS runners are expensive and slow)
           - os: macos-latest
-            bazelversion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
-            zigversion: 0.12.0
+            bazelVersion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
+            zigVersion: 0.12.0
             bzlmodEnabled: false
             folder: "."
-            target: "//..."
+            targetPattern: "//..."
           - os: macos-latest
-            bazelversion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
-            zigversion: 0.12.0
+            bazelVersion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
+            zigVersion: 0.12.0
             bzlmodEnabled: true
             folder: "."
-            target: "//..."
+            targetPattern: "//..."
           - os: macos-latest
-            bazelversion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
-            zigversion: 0.12.0
+            bazelVersion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
+            zigVersion: 0.12.0
             bzlmodEnabled: false
             folder: "e2e/workspace"
-            target: "//..."
+            targetPattern: "//..."
           - os: macos-latest
-            bazelversion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
-            zigversion: 0.12.0
+            bazelVersion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
+            zigVersion: 0.12.0
             bzlmodEnabled: true
             folder: "e2e/workspace"
-            target: "//..."
+            targetPattern: "//..."
 
     # Configure a human readable name for each job
-    name: Test ${{ matrix.target }} in ${{ matrix.folder }} with Zig ${{ matrix.zigversion }}, Bazel ${{ matrix.bazelversion }}, and bzlmod ${{ matrix.bzlmodEnabled }} on ${{ matrix.os }}
+    name: Test ${{ matrix.targetPattern }} in ${{ matrix.folder }} with Zig ${{ matrix.zigVersion }}, Bazel ${{ matrix.bazelVersion }}, and bzlmod ${{ matrix.bzlmodEnabled }} on ${{ matrix.os }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -151,7 +151,7 @@ jobs:
         with:
           os: ${{ matrix.os }}
           folder: ${{ matrix.folder }}
-          bazelVersion: ${{ matrix.bazelversion }}
+          bazelVersion: ${{ matrix.bazelVersion }}
           bzlmodEnabled: ${{ matrix.bzlmodEnabled }}
           # Disable documentation generation for all but the first Bazel
           # version, by setting --no@rules_zig//docs:build_docs in
@@ -159,9 +159,9 @@ jobs:
           # versions. For example, Bazel version 7 changed the documentation of
           # the implicit `repo_mapping` parameter to repository rules compared
           # to Bazel version 6.
-          docsEnabled: ${{ matrix.bazelversion == fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
-          zigVersion: ${{ matrix.zigversion }}
-          targetPattern: ${{ matrix.target }}
+          docsEnabled: ${{ matrix.bazelVersion == fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
+          zigVersion: ${{ matrix.zigVersion }}
+          targetPattern: ${{ matrix.targetPattern }}
 
   all_tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -203,6 +203,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - matrix-prep-bazelversion
+      - matrix-prep-zigversion
       - test-bazel-versions
       - test-zig-versions
       - integration-tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -147,100 +147,21 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
 
-      # Cache build and external artifacts so that the next ci build is incremental.
-      # Because github action caches cannot be updated after a build, we need to
-      # store the contents of each build in a unique cache key, then fall back to loading
-      # it on the next ci run. We use hashFiles(...) in the key and restore-keys- with
-      # the prefix to load the most recent cache for the branch on a cache miss. You
-      # should customize the contents of hashFiles to capture any bazel input sources,
-      # although this doesn't need to be perfect. If none of the input sources change
-      # then a cache hit will load an existing cache and bazel won't have to do any work.
-      # In the case of a cache miss, you want the fallback cache to contain most of the
-      # previously built artifacts to minimize build time. The more precise you are with
-      # hashFiles sources the less work bazel will have to do.
-      - name: Mount bazel caches
-        uses: actions/cache@v4
+      - uses: ./.github/actions/test
         with:
-          path: |
-            ~/.cache/bazel
-            ~/.cache/bazel-repo
-          key: bazel-cache-${{ matrix.os }}-${{ matrix.zigversion }}-${{ matrix.bazelversion }}-${{ matrix.bzlmodEnabled }}-${{ matrix.folder }}-${{ matrix.target }}-${{ hashFiles('**/BUILD.bazel', '**/*.bzl', '**/*.zig', 'WORKSPACE', 'WORKSPACE.bzlmod', 'MODULE.bazel') }}
-          restore-keys: |
-            bazel-cache-${{ matrix.os }}-${{ matrix.bazelversion }}-${{ matrix.bzlmodEnabled }}-${{ matrix.folder }}-${{ matrix.target }}
-
-      - name: Configure remote cache and execution
-        working-directory: ${{ matrix.folder }}
-        run: |
-          cat <<EOF >>.bazelrc.user
-          build --config=remote-bes --config=remote-cache
-          # Remote execution on non-Linux is only available for BuildBuddy Enterprise.
-          build:linux --config=remote
-          EOF
-          cat <<EOF >>.bazelrc.ic.user
-          build --config=remote-bes --config=remote-cache
-          # Remote execution on non-Linux is only available for BuildBuddy Enterprise.
-          build:linux --config=remote
-          EOF
-
-      - name: Configure Bazel version
-        working-directory: ${{ matrix.folder }}
-        run: echo "USE_BAZEL_VERSION=${{ matrix.bazelversion }}" > .bazeliskrc
-
-      - name: Configure Zig version
-        working-directory: ${{ matrix.folder }}
-        run: echo "build --@zig_toolchains//:version=${{ matrix.zigversion }}" >> .bazelrc.user
-
-      - name: Configure documentation generation
-        if: matrix.folder == '.' && matrix.target == '//...'
-        run: |
+          os: ${{ matrix.os }}
+          folder: ${{ matrix.folder }}
+          bazelVersion: ${{ matrix.bazelversion }}
+          bzlmodEnabled: ${{ matrix.bzlmodEnabled }}
           # Disable documentation generation for all but the first Bazel
           # version, by setting --no@rules_zig//docs:build_docs in
           # .bazelrc.user. The generated documentation can vary between Bazel
           # versions. For example, Bazel version 7 changed the documentation of
           # the implicit `repo_mapping` parameter to repository rules compared
           # to Bazel version 6.
-          PREFIX=${{ matrix.bazelversion == fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] && '' || 'no' }}
-          echo "common --$PREFIX@rules_zig//docs:build_docs" >> .bazelrc.user
-
-      - name: Set bzlmod flag
-        working-directory: ${{ matrix.folder }}
-        # Set --enable_bzlmod if bzlmodEnabled is true, else --noenable_bzlmod.
-        id: set_bzlmod_flag
-        run: |
-          echo "common ${{ matrix.bzlmodEnabled && '--enable_bzlmod' || '--noenable_bzlmod' }}" >> .bazelrc.user
-          echo "bzlmod_flag=${{ matrix.bzlmodEnabled && '--enable_bzlmod' || '--noenable_bzlmod' }}" >> $GITHUB_OUTPUT
-
-      - name: Test generated files
-        if: matrix.folder == '.' && matrix.target == '//...'
-        run: |
-          # Bazelisk will download bazel to here, ensure it is cached between runs.
-          export XDG_CACHE_HOME="$HOME/.cache/bazel-repo"
-          bazel --bazelrc=$GITHUB_WORKSPACE/.github/workflows/ci.bazelrc --bazelrc=.bazelrc run //util:update
-          test -z $(git status --porcelain) || { echo "Update generated files using `bazel run //util:update`" >&2; git diff >&2; exit 1; }
-
-      - name: Check for test.sh
-        # Checks for the existence of test.sh in the folder. Downstream steps can use
-        # steps.has_test_sh.outputs.files_exists as a conditional.
-        id: has_test_sh
-        uses: andstor/file-existence-action@v3
-        with:
-          files: "${{ matrix.folder }}/test.sh"
-
-      - name: bazel test ${{ matrix.target }}
-        working-directory: ${{ matrix.folder }}
-        run: |
-          # Bazelisk will download bazel to here, ensure it is cached between runs.
-          export XDG_CACHE_HOME="$HOME/.cache/bazel-repo"
-          bazel --bazelrc=$GITHUB_WORKSPACE/.github/workflows/ci.bazelrc --bazelrc=.bazelrc test ${{ matrix.target }}
-
-      - name: ./test.sh
-        # Run if there is a test.sh file in the folder
-        if: steps.has_test_sh.outputs.files_exists == 'true'
-        working-directory: ${{ matrix.folder }}
-        shell: bash
-        # Run the script potentially setting BZLMOD_FLAG=--enable_bzlmod. All test.sh
-        # scripts that run bazel directly should make use of this variable.
-        run: BZLMOD_FLAG=${{ steps.set_bzlmod_flag.outputs.bzlmod_flag }} ./test.sh
+          docsEnabled: ${{ matrix.bazelversion == fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
+          zigVersion: ${{ matrix.zigversion }}
+          targetPattern: ${{ matrix.target }}
 
   all_tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -125,6 +125,10 @@ jobs:
           - "."
           - "e2e/workspace"
         targetPattern: ["//..."]
+        exclude:
+          # This combination is already tested in test-bazel-versions
+          - bazelVersion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
+            zigVersion: ${{ fromJSON(needs.matrix-prep-zigversion.outputs.zigversions)[0] }}
 
     # Configure a human readable name for each job
     name: Test ${{ matrix.targetPattern }} in ${{ matrix.folder }} with Zig ${{ matrix.zigVersion }}, Bazel ${{ matrix.bazelVersion }}, and bzlmod ${{ matrix.bzlmodEnabled }} on ${{ matrix.os }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,27 +79,6 @@ jobs:
           - "."
           - "e2e/workspace"
         targetPattern: ["//..."]
-        include:
-          # The integration tests iterate over all supported Bazel versions, so
-          # we only run them against the latest Bazel version.
-          - os: ubuntu-latest
-            bazelVersion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
-            zigVersion: 0.12.0
-            bzlmodEnabled: false
-            folder: "."
-            targetPattern: "//zig/tests/integration_tests"
-          - os: ubuntu-latest
-            bazelVersion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
-            zigVersion: 0.12.0
-            bzlmodEnabled: true
-            folder: "."
-            targetPattern: "//zig/tests/integration_tests"
-          - os: macos-latest
-            bazelVersion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
-            zigVersion: 0.12.0
-            bzlmodEnabled: true
-            folder: "."
-            targetPattern: "//zig/tests/integration_tests"
 
     # Configure a human readable name for each job
     name: Test ${{ matrix.targetPattern }} in ${{ matrix.folder }} with Zig ${{ matrix.zigVersion }}, Bazel ${{ matrix.bazelVersion }}, and bzlmod ${{ matrix.bzlmodEnabled }} on ${{ matrix.os }}
@@ -171,12 +150,58 @@ jobs:
           zigVersion: ${{ matrix.zigVersion }}
           targetPattern: ${{ matrix.targetPattern }}
 
+  integration-tests:
+    # The type of runner that the job will run on
+    runs-on: ${{ matrix.os }}
+
+    needs:
+      - matrix-prep-bazelversion
+      - matrix-prep-zigversion
+
+    # Run bazel test in each workspace with each version of Bazel supported
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        bazelVersion:
+          - ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
+        zigVersion:
+          - ${{ fromJSON(needs.matrix-prep-zigversion.outputs.zigversions)[0] }}
+        bzlmodEnabled: [true, false]
+        folder: ["."]
+        targetPattern: ["//zig/tests/integration_tests"]
+
+    # Configure a human readable name for each job
+    name: Test ${{ matrix.targetPattern }} in ${{ matrix.folder }} with Zig ${{ matrix.zigVersion }}, Bazel ${{ matrix.bazelVersion }}, and bzlmod ${{ matrix.bzlmodEnabled }} on ${{ matrix.os }}
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/test
+        with:
+          os: ${{ matrix.os }}
+          folder: ${{ matrix.folder }}
+          bazelVersion: ${{ matrix.bazelVersion }}
+          bzlmodEnabled: ${{ matrix.bzlmodEnabled }}
+          # Disable documentation generation for all but the first Bazel
+          # version, by setting --no@rules_zig//docs:build_docs in
+          # .bazelrc.user. The generated documentation can vary between Bazel
+          # versions. For example, Bazel version 7 changed the documentation of
+          # the implicit `repo_mapping` parameter to repository rules compared
+          # to Bazel version 6.
+          docsEnabled: ${{ matrix.bazelVersion == fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
+          zigVersion: ${{ matrix.zigVersion }}
+          targetPattern: ${{ matrix.targetPattern }}
+
   all_tests:
     runs-on: ubuntu-latest
     needs:
       - matrix-prep-bazelversion
       - test-bazel-versions
       - test-zig-versions
+      - integration-tests
     if: ${{ always() }}
     steps:
       - uses: cgrindel/gha_join_jobs@v1.2.0


### PR DESCRIPTION
Create a composite workflow for the actual CI pipeline and simplify the CI matrix by defining separate jobs for separate main parameter axes.

- **Factor out GitHub CI into composite workflow**
- **Consistent Matrix parameter spelling**
- **Load Zig versions into GH workflow**
- **Dedicated axis for Bazel versions**
- **Dedicated Zig version tests**
- **Dedicated integration tests**
- **Avoid duplicate Bazel and Zig latest version test**
- **all tests depends on zig versions**
