### PR TITLE
chore: update Zig HEAD version test

### DIFF
--- a/zig/tests/integration_tests/BUILD.bazel
+++ b/zig/tests/integration_tests/BUILD.bazel
@@ -52,7 +52,7 @@ bazel_integration_tests(
 )
 
 TEST_VERSIONS = TOOL_VERSIONS.keys() + [
-    "0.13.0-dev.46+3648d7df1",
+    "0.14.0-dev.1632+d83a3f174",
 ]
 
 [

--- a/zig/tests/integration_tests/workspace/MODULE.bazel
+++ b/zig/tests/integration_tests/workspace/MODULE.bazel
@@ -10,7 +10,7 @@ local_path_override(
 
 zig = use_extension("@rules_zig//zig:extensions.bzl", "zig")
 zig.index(file = "extra-versions.json")
-zig.toolchain(zig_version = "0.13.0-dev.46+3648d7df1")
+zig.toolchain(zig_version = "0.14.0-dev.1632+d83a3f174")
 zig.toolchain(
     default = True,
     zig_version = "0.13.0",

--- a/zig/tests/integration_tests/workspace/extra-versions.json
+++ b/zig/tests/integration_tests/workspace/extra-versions.json
@@ -1,73 +1,73 @@
 {
   "master": {
-    "version": "0.13.0-dev.46+3648d7df1",
-    "date": "2024-04-26",
+    "version": "0.14.0-dev.1632+d83a3f174",
+    "date": "2024-09-20",
     "docs": "https://ziglang.org/documentation/master/",
     "stdDocs": "https://ziglang.org/documentation/master/std/",
     "src": {
-      "tarball": "https://ziglang.org/builds/zig-0.13.0-dev.46+3648d7df1.tar.xz",
-      "shasum": "08190cb4482be355acaecaae9d7936e4fad47180c97ca8138b97a122a313cd99",
-      "size": "17111524"
+      "tarball": "https://ziglang.org/builds/zig-0.14.0-dev.1632+d83a3f174.tar.xz",
+      "shasum": "0bb327af1c49c0d9b4b7a2fb81c8c2c48c2414edc6ca01bde5f742eaa1310380",
+      "size": "17586240"
     },
     "bootstrap": {
-      "tarball": "https://ziglang.org/builds/zig-bootstrap-0.13.0-dev.46+3648d7df1.tar.xz",
-      "shasum": "78569b44dbfb8ec0cddbd1fa69ce398b973bd05c7f3b87f070cc2a0ba9c86571",
-      "size": "45555796"
+      "tarball": "https://ziglang.org/builds/zig-bootstrap-0.14.0-dev.1632+d83a3f174.tar.xz",
+      "shasum": "d7c0b2935a33f140ee5e7f2a5806f40d4f3592809c94bd77dfc0e0b606142b97",
+      "size": "47853636"
     },
     "x86_64-macos": {
-      "tarball": "https://ziglang.org/builds/zig-macos-x86_64-0.13.0-dev.46+3648d7df1.tar.xz",
-      "shasum": "d8fb090bd69d7e191a3443520da5c52da430fbffc0de12ac87a114a6cc1f20ca",
-      "size": "47206948"
+      "tarball": "https://ziglang.org/builds/zig-macos-x86_64-0.14.0-dev.1632+d83a3f174.tar.xz",
+      "shasum": "6e1b4470cfbdbf13de9c10884f2c7e06ef69b0e50ce514a53b890827958973ca",
+      "size": "50768248"
     },
     "aarch64-macos": {
-      "tarball": "https://ziglang.org/builds/zig-macos-aarch64-0.13.0-dev.46+3648d7df1.tar.xz",
-      "shasum": "37784926f45e5aba87f72f19de704adcb30604871df0c3ef6c0d177ae84bb741",
-      "size": "43466292"
+      "tarball": "https://ziglang.org/builds/zig-macos-aarch64-0.14.0-dev.1632+d83a3f174.tar.xz",
+      "shasum": "987f2e8d86762ecdbe22f2981785755dd0e5a71d8255df4e2fee57f653d7c295",
+      "size": "46723248"
     },
     "x86_64-linux": {
-      "tarball": "https://ziglang.org/builds/zig-linux-x86_64-0.13.0-dev.46+3648d7df1.tar.xz",
-      "shasum": "746e1102a6452722d382252cc6aed8728c7389ea16431bf5bc5ba0adc0f7e524",
-      "size": "45513200"
+      "tarball": "https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.1632+d83a3f174.tar.xz",
+      "shasum": "db5f935ab6f2df2d9838d066702da159f4d6df5985d5e5f69cbf57c4817e0de9",
+      "size": "48846476"
     },
     "aarch64-linux": {
-      "tarball": "https://ziglang.org/builds/zig-linux-aarch64-0.13.0-dev.46+3648d7df1.tar.xz",
-      "shasum": "b18710c4b62663be0b31aac80ef6916bf6763070e5fe3201ee273f033d828a70",
-      "size": "41880840"
+      "tarball": "https://ziglang.org/builds/zig-linux-aarch64-0.14.0-dev.1632+d83a3f174.tar.xz",
+      "shasum": "aa3a871ba34f8b3c1f0dfc112ddb87c05b2e4ff0a82f22ae245fb8a96e306076",
+      "size": "44845892"
     },
     "armv7a-linux": {
-      "tarball": "https://ziglang.org/builds/zig-linux-armv7a-0.13.0-dev.46+3648d7df1.tar.xz",
-      "shasum": "a5f20e3cdbe8b3d88c83d6ac7a3739f18ba7d2c5f20c31c5d3a765427593be48",
-      "size": "42686280"
+      "tarball": "https://ziglang.org/builds/zig-linux-armv7a-0.14.0-dev.1632+d83a3f174.tar.xz",
+      "shasum": "4fbffa02b23be5c4061a14503797471e5e76442b7aa231a1e8c1e53e26380c2c",
+      "size": "45869808"
     },
     "riscv64-linux": {
-      "tarball": "https://ziglang.org/builds/zig-linux-riscv64-0.13.0-dev.46+3648d7df1.tar.xz",
-      "shasum": "e41ea9b6cfa9c653614ffeee77e7ae1212201dfabdb02bd70aad191232947da1",
-      "size": "43932784"
+      "tarball": "https://ziglang.org/builds/zig-linux-riscv64-0.14.0-dev.1632+d83a3f174.tar.xz",
+      "shasum": "c39e5b6e4fb8f27f4bde900af2bf240b09e7ecc82d71e813698d1daecb7fbe6d",
+      "size": "47413784"
     },
     "powerpc64le-linux": {
-      "tarball": "https://ziglang.org/builds/zig-linux-powerpc64le-0.13.0-dev.46+3648d7df1.tar.xz",
-      "shasum": "611edc13d17a26a0f6ca6723bd86e0bb28270415fadfcafaebd03240ae649e0a",
-      "size": "45260476"
+      "tarball": "https://ziglang.org/builds/zig-linux-powerpc64le-0.14.0-dev.1632+d83a3f174.tar.xz",
+      "shasum": "dd363d9dd014b9db563fd3e47acc13a4d7f6262fd90cef5fbb274a6114f13e2c",
+      "size": "48369376"
     },
     "x86-linux": {
-      "tarball": "https://ziglang.org/builds/zig-linux-x86-0.13.0-dev.46+3648d7df1.tar.xz",
-      "shasum": "f078dc7cf4610149a5e444a1e3bec9d336b6d09c44310969d3111638b784a754",
-      "size": "50565396"
+      "tarball": "https://ziglang.org/builds/zig-linux-x86-0.14.0-dev.1632+d83a3f174.tar.xz",
+      "shasum": "c33c4e488c90b7cde9645f92ef7c55ddd3537b1281ea03884074162d55d93df8",
+      "size": "54104316"
     },
     "x86_64-windows": {
-      "tarball": "https://ziglang.org/builds/zig-windows-x86_64-0.13.0-dev.46+3648d7df1.zip",
-      "shasum": "7c76330891cc1283151defede948b67a568920dfde3a723a64a101c5e67d68ed",
-      "size": "77031600"
+      "tarball": "https://ziglang.org/builds/zig-windows-x86_64-0.14.0-dev.1632+d83a3f174.zip",
+      "shasum": "4dfb3baf7b969581811835fe8058574cf7c1a6c130c42ebd1958d6c5170938f2",
+      "size": "82856178"
     },
     "aarch64-windows": {
-      "tarball": "https://ziglang.org/builds/zig-windows-aarch64-0.13.0-dev.46+3648d7df1.zip",
-      "shasum": "fc8541916e36f4a767b6661c72473399bf5e32481d5ac5ab29b385992c770b34",
-      "size": "73556923"
+      "tarball": "https://ziglang.org/builds/zig-windows-aarch64-0.14.0-dev.1632+d83a3f174.zip",
+      "shasum": "86f6dc6711843d03c99e519aba53f77f5bf5b8af6da6de6db626df76ea8ee7a1",
+      "size": "78857537"
     },
     "x86-windows": {
-      "tarball": "https://ziglang.org/builds/zig-windows-x86-0.13.0-dev.46+3648d7df1.zip",
-      "shasum": "f32665b9763f7a862a72bc1833ca35e284ae73b5055ff57e22abad21c8e8beb5",
-      "size": "81538193"
+      "tarball": "https://ziglang.org/builds/zig-windows-x86-0.14.0-dev.1632+d83a3f174.zip",
+      "shasum": "1312dc0857dd8379f1d25459140827541fe51c7191f2dff22bc6ab6e0e22bbff",
+      "size": "87118145"
     }
   }
 }


### PR DESCRIPTION
The download of the previously configured version was no longer available.
