### PR TITLE
chore: configure BuildBuddy credentials

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -11,6 +11,9 @@ import %workspace%/.bazelrc.flags
 # Remote cache configuration.
 import %workspace%/.bazelrc.remote
 
+# docs: https://bazel.build/reference/command-line-reference#flag--workspace_status_command
+build --workspace_status_command=$(pwd)/workspace_status.sh
+
 # Deleted packages for integration tests.
 # To update these lines, execute
 # `bazel run @rules_bazel_integration_test//tools:update_deleted_packages`

--- a/.bazelrc.remote
+++ b/.bazelrc.remote
@@ -14,14 +14,14 @@ build:remote-bes --experimental_profile_include_primary_output
 build:remote-bes --nolegacy_important_outputs
 
 # docs: https://bazel.build/reference/command-line-reference#flag--bes_results_url
-build:remote-bes --bes_results_url=https://app.buildbuddy.io/invocation/
+build:remote-bes --bes_results_url=https://aherrmann.buildbuddy.io/invocation/
 # docs: https://bazel.build/reference/command-line-reference#flag--bes_backend
-build:remote-bes --bes_backend=grpcs://remote.buildbuddy.io
+build:remote-bes --bes_backend=grpcs://aherrmann.buildbuddy.io
 
 # Remote cache setup.
 
 # docs: https://bazel.build/reference/command-line-reference#flag--remote_cache
-build:remote-cache --remote_cache=grpcs://remote.buildbuddy.io
+build:remote-cache --remote_cache=grpcs://aherrmann.buildbuddy.io
 # docs: https://bazel.build/reference/command-line-reference#flag--remote_cache_compression
 build:remote-cache --remote_cache_compression
 # docs: https://bazel.build/reference/command-line-reference#flag--remote_download_toplevel
@@ -32,9 +32,9 @@ build:remote-cache --remote_timeout=3600
 # Remote execution setup.
 
 # docs: https://bazel.build/reference/command-line-reference#flag--remote_executor
-build:remote-exec --remote_executor=grpcs://remote.buildbuddy.io
+build:remote-exec --remote_executor=grpcs://aherrmann.buildbuddy.io
 # docs: https://bazel.build/reference/command-line-reference#flag--experimental_remote_downloader
-build:remote-exec --experimental_remote_downloader=grpcs://remote.buildbuddy.io
+build:remote-exec --experimental_remote_downloader=grpcs://aherrmann.buildbuddy.io
 
 # docs: https://bazel.build/reference/command-line-reference#flag--jobs
 build:remote-exec --jobs=80

--- a/.bazelrc.remote
+++ b/.bazelrc.remote
@@ -28,6 +28,10 @@ build:remote-cache --remote_cache_compression
 build:remote-cache --remote_download_toplevel
 # docs: https://bazel.build/reference/command-line-reference#flag--remote_timeout
 build:remote-cache --remote_timeout=3600
+# docs: https://bazel.build/reference/command-line-reference#flag--experimental_remote_cache_ttl
+build:remote-cache --experimental_remote_cache_ttl=3h
+# docs: https://bazel.build/reference/command-line-reference#flag--experimental_remote_cache_lease_extension
+build:remote-cache --experimental_remote_cache_lease_extension
 
 # Remote execution setup.
 

--- a/.github/actions/test/action.yaml
+++ b/.github/actions/test/action.yaml
@@ -22,6 +22,9 @@ inputs:
   targetPattern:
     description: "The Bazel build and test target pattern."
     required: true
+  buildbuddyApiKey:
+    description: "The API key for BuildBuddy remote cache and execution."
+    required: true
 runs:
   using: composite
   steps:
@@ -50,7 +53,7 @@ runs:
       working-directory: ${{ inputs.folder }}
       shell: bash
       env:
-        BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+        BUILDBUDDY_API_KEY: ${{ inputs.buildbuddyApiKey }}
       run: |
         cat <<EOF >>.bazelrc.user
         build --build_metadata=ROLE=CI

--- a/.github/actions/test/action.yaml
+++ b/.github/actions/test/action.yaml
@@ -49,14 +49,16 @@ runs:
     - name: Configure remote cache and execution
       working-directory: ${{ inputs.folder }}
       shell: bash
+      env:
+        BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
       run: |
         cat <<EOF >>.bazelrc.user
-        build --config=remote-bes --config=remote-cache
+        build --config=remote-bes --config=remote-cache --remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY
         # Remote execution on non-Linux is only available for BuildBuddy Enterprise.
         build:linux --config=remote
         EOF
         cat <<EOF >>.bazelrc.ic.user
-        build --config=remote-bes --config=remote-cache
+        build --config=remote-bes --config=remote-cache --remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY
         # Remote execution on non-Linux is only available for BuildBuddy Enterprise.
         build:linux --config=remote
         EOF

--- a/.github/actions/test/action.yaml
+++ b/.github/actions/test/action.yaml
@@ -2,7 +2,7 @@ name: Run Tests
 description: Run all tests for a specific configuration.
 inputs:
   os:
-    description: "The runer's operating system, used in cache keys."
+    description: "The runner's operating system, used in cache keys."
     required: true
   folder:
     description: "The folder to run builds and tests in."

--- a/.github/actions/test/action.yaml
+++ b/.github/actions/test/action.yaml
@@ -53,11 +53,13 @@ runs:
         BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
       run: |
         cat <<EOF >>.bazelrc.user
+        build --build_metadata=ROLE=CI
         build --config=remote-bes --config=remote-cache --remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY
         # Remote execution on non-Linux is only available for BuildBuddy Enterprise.
         build:linux --config=remote
         EOF
         cat <<EOF >>.bazelrc.ic.user
+        build --build_metadata=ROLE=CI
         build --config=remote-bes --config=remote-cache --remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY
         # Remote execution on non-Linux is only available for BuildBuddy Enterprise.
         build:linux --config=remote

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,6 +103,7 @@ jobs:
           docsEnabled: ${{ matrix.bazelVersion == fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
           zigVersion: ${{ matrix.zigVersion }}
           targetPattern: ${{ matrix.targetPattern }}
+          buildbuddyApiKey: ${{ secrets.BUILDBUDDY_API_KEY }}
 
   test-zig-versions:
     # The type of runner that the job will run on
@@ -153,6 +154,7 @@ jobs:
           docsEnabled: ${{ matrix.bazelVersion == fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
           zigVersion: ${{ matrix.zigVersion }}
           targetPattern: ${{ matrix.targetPattern }}
+          buildbuddyApiKey: ${{ secrets.BUILDBUDDY_API_KEY }}
 
   integration-tests:
     # The type of runner that the job will run on
@@ -198,6 +200,7 @@ jobs:
           docsEnabled: ${{ matrix.bazelVersion == fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
           zigVersion: ${{ matrix.zigVersion }}
           targetPattern: ${{ matrix.targetPattern }}
+          buildbuddyApiKey: ${{ secrets.BUILDBUDDY_API_KEY }}
 
   all_tests:
     runs-on: ubuntu-latest

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -49,6 +49,12 @@ load("@buildifier_prebuilt//:defs.bzl", "buildifier_prebuilt_register_toolchains
 
 buildifier_prebuilt_register_toolchains()
 
+load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies", "aspect_bazel_lib_register_toolchains")
+
+aspect_bazel_lib_dependencies()
+
+aspect_bazel_lib_register_toolchains()
+
 # For running integration tests
 load("@rules_bazel_integration_test//bazel_integration_test:deps.bzl", "bazel_integration_test_rules_dependencies")
 

--- a/e2e/workspace/.bazelrc
+++ b/e2e/workspace/.bazelrc
@@ -2,3 +2,6 @@
 try-import %workspace%/../../.bazelrc.common
 try-import %workspace%/../../.bazelrc.remote
 try-import %workspace%/.bazelrc.user
+
+# docs: https://bazel.build/reference/command-line-reference#flag--workspace_status_command
+build --workspace_status_command=$(pwd)/workspace_status.sh

--- a/e2e/workspace/workspace_status.sh
+++ b/e2e/workspace/workspace_status.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+STATUS_SCRIPT="$SCRIPT_DIR/../../workspace_status.sh"
+[[ -f "$STATUS_SCRIPT" ]] && exec "$STATUS_SCRIPT"

--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -61,6 +61,13 @@ def rules_zig_internal_deps():
         ],
     )
 
+    http_archive(
+        name = "aspect_bazel_lib",
+        sha256 = "da67c6a785cdc10faf960a22c44501fe6be357a6ebd2bd6101560f9c2a9e06b3",
+        strip_prefix = "bazel-lib-2.9.0",
+        url = "https://github.com/bazel-contrib/bazel-lib/releases/download/v2.9.0/bazel-lib-v2.9.0.tar.gz",
+    )
+
     # Override bazel_skylib distribution to fetch sources instead
     # so that the gazelle extension is included
     # see https://github.com/bazelbuild/bazel-skylib/issues/250

--- a/workspace_status.sh
+++ b/workspace_status.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# This script will be run bazel when building process starts to
+# generate key-value information that represents the status of the
+# workspace. The output should be like
+#
+# KEY1 VALUE1
+# KEY2 VALUE2
+#
+# If the script exits with non-zero code, it's considered as a failure
+# and the output will be discarded.
+
+set -eo pipefail # exit immediately if any command fails.
+
+function remove_url_credentials() {
+  which perl >/dev/null && perl -pe 's#//.*?:.*?@#//#' || cat
+}
+
+if git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
+
+  repo_url=$(git config --get remote.origin.url | remove_url_credentials)
+  echo "REPO_URL $repo_url"
+
+  commit_sha=$(git rev-parse HEAD)
+  echo "COMMIT_SHA $commit_sha"
+
+  git_branch=$(git rev-parse --abbrev-ref HEAD)
+  echo "GIT_BRANCH $git_branch"
+
+  git_tree_status=$(git diff-index --quiet HEAD -- && echo 'Clean' || echo 'Modified')
+  echo "GIT_TREE_STATUS $git_tree_status"
+
+  # Note: the "STABLE_" suffix causes these to be part of the "stable" workspace
+  # status, which may trigger rebuilds of certain targets if these values change
+  # and you're building with the "--stamp" flag.
+  latest_version_tag=$(
+      git tag -l 'v*' --sort=creatordate |
+          perl -nle 'if (/^v\d+\.\d+\.\d+$/) { print $_ }' |
+          tail -n1
+  )
+  echo "STABLE_VERSION_TAG $latest_version_tag"
+  echo "STABLE_COMMIT_SHA $commit_sha"
+
+else
+
+  echo "REPO_URL "
+  echo "COMMIT_SHA "
+  echo "GIT_BRANCH "
+  echo "GIT_TREE_STATUS "
+  echo "STABLE_VERSION_TAG "
+  echo "STABLE_COMMIT_SHA "
+
+fi

--- a/zig/tests/integration_tests/.bazelrc.meta.tpl
+++ b/zig/tests/integration_tests/.bazelrc.meta.tpl
@@ -1,0 +1,3 @@
+build --build_metadata=REPO_URL={{REPO_URL}}
+build --build_metadata=BRANCH_NAME={{GIT_BRANCH}}
+build --build_metadata=COMMIT_SHA={{COMMIT_SHA}}

--- a/zig/tests/integration_tests/BUILD.bazel
+++ b/zig/tests/integration_tests/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@aspect_bazel_lib//lib:expand_template.bzl", "expand_template_rule")
 load("@bazel_binaries//:defs.bzl", "bazel_binaries")
 load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
@@ -11,6 +12,24 @@ load("//zig:defs.bzl", "zig_module", "zig_test")
 load("//zig/private:versions.bzl", "TOOL_VERSIONS")
 
 # gazelle:exclude workspace
+
+expand_template_rule(
+    name = "build_metadata",
+    out = ".bazelrc.meta",
+    stamp = 1,
+    stamp_substitutions = {
+        "{{REPO_URL}}": "{{REPO_URL}}",
+        "{{GIT_BRANCH}}": "{{GIT_BRANCH}}",
+        "{{COMMIT_SHA}}": "{{COMMIT_SHA}}",
+    },
+    template = ".bazelrc.meta.tpl",
+)
+
+workspace_files = integration_test_utils.glob_workspace_files("workspace") + [
+    "//:all_files",
+    "//:bazelrc",
+    ".bazelrc.meta",
+]
 
 zig_module(
     name = "integration_testing",
@@ -30,10 +49,7 @@ bazel_integration_tests(
     bazel_versions = bazel_binaries.versions.all,
     tags = ["requires-network"] + integration_test_utils.DEFAULT_INTEGRATION_TEST_TAGS,
     test_runner = ":integration_tests_runner",
-    workspace_files = integration_test_utils.glob_workspace_files("workspace") + [
-        "//:all_files",
-        "//:bazelrc",
-    ],
+    workspace_files = workspace_files,
     workspace_path = "workspace",
 )
 
@@ -44,10 +60,7 @@ bazel_integration_tests(
     env = {"BZLMOD_ENABLED": "true"},
     tags = ["requires-network"] + integration_test_utils.DEFAULT_INTEGRATION_TEST_TAGS,
     test_runner = ":integration_tests_runner",
-    workspace_files = integration_test_utils.glob_workspace_files("workspace") + [
-        "//:all_files",
-        "//:bazelrc",
-    ],
+    workspace_files = workspace_files,
     workspace_path = "workspace",
 )
 
@@ -97,10 +110,7 @@ bazel_integration_test(
     bazel_version = bazel_binaries.versions.current,
     tags = ["requires-network"] + integration_test_utils.DEFAULT_INTEGRATION_TEST_TAGS,
     test_runner = ":zig_version_tests_runner",
-    workspace_files = integration_test_utils.glob_workspace_files("workspace") + [
-        "//:all_files",
-        "//:bazelrc",
-    ],
+    workspace_files = workspace_files,
     workspace_path = "workspace",
 )
 

--- a/zig/tests/integration_tests/workspace/.bazelrc
+++ b/zig/tests/integration_tests/workspace/.bazelrc
@@ -7,5 +7,8 @@ import %workspace%/../../../../.bazelrc.flags
 # Remote cache configuration.
 import %workspace%/../../../../.bazelrc.remote
 
+# Build metadata
+import %workspace%/../.bazelrc.meta
+
 # Load any settings specific to the current user.
 try-import %workspace%/../../../../.bazelrc.ic.user


### PR DESCRIPTION
Anonymous BuildBuddy builds are now deprecated.
This switches the build and CI to use an access token. 

- **Configure BuildBuddy account**
- **Configure repository secret**
- **Set up build metadata through workspace status**
