### PR TITLE
chore: Bump minimal Bazel version to 7.1.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -51,13 +51,13 @@ bazel_binaries = use_extension(
 
 # NOTE: Keep in sync with WORKSPACE.
 bazel_binaries.download(version_file = "//:.bazelversion")
-bazel_binaries.download(version = "7.0.0")
+bazel_binaries.download(version = "7.1.0")
 use_repo(
     bazel_binaries,
     "bazel_binaries",
     "bazel_binaries_bazelisk",
     "build_bazel_bazel_.bazelversion",
-    "build_bazel_bazel_7_0_0",
+    "build_bazel_bazel_7_1_0",
 )
 
 # TODO[AH] Should be an implicit transitive dependency through rules_bazel_integration_test.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -69,7 +69,7 @@ load("@rules_bazel_integration_test//bazel_integration_test:defs.bzl", "bazel_bi
 # NOTE: Keep in sync with MODULE.bazel.
 bazel_binaries(versions = [
     "//:.bazelversion",
-    "7.0.0",
+    "7.1.0",
 ])
 
 # Stardoc dependencies


### PR DESCRIPTION
rules_cc >=0.0.12 requires Bazel >=7.1.0 to specifiy `extension_metadata(reproducible=...)`.
