### PR TITLE
chore: pass token secrets from release workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,10 @@ on:
 
   # Allows you to call this workflow from another workflow
   workflow_call:
+    secrets:
+      BUILDBUDDY_API_KEY:
+        description: The BuildBuddy remote execution access token.
+        required: true
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ permissions:
 jobs:
   tests:
     uses: ./.github/workflows/ci.yaml
+    secrets:
+      BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
 
   release:
     needs: [tests]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,6 @@ repos:
       - id: renovate-config-validator
   # Check validity of GitHub actions configuration
   - repo: https://github.com/mpalmer/action-validator
-    rev: v0.5.1
+    rev: v0.6.0
     hooks:
       - id: action-validator


### PR DESCRIPTION
- **chore: update GH action validator**
- **expect BuildBuddy token on CI workflow_call**
- **pass the BuildBuddy token from release workflow**
