### PR TITLE
fix: work around Zig docs build failures

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -8,6 +8,8 @@ tasks:
     bazel: ${{ bazel }}
     build_targets:
       - "//..."
+    build_flags:
+      - "--build_tag_filters=-zig-docs"
 bcr_test_module:
   module_path: "e2e/workspace"
   matrix:
@@ -20,3 +22,5 @@ bcr_test_module:
       bazel: ${{ bazel }}
       test_targets:
         - "//..."
+      test_flags:
+        - "--test_tag_filters=-zig-docs"

--- a/.github/actions/test/action.yaml
+++ b/.github/actions/test/action.yaml
@@ -32,6 +32,9 @@ inputs:
   buildbuddyApiKey:
     description: "The API key for BuildBuddy remote cache and execution."
     required: true
+  bazelFlags:
+    description: "Additional flags to pass to Bazel."
+    required: false
 runs:
   using: composite
   steps:
@@ -123,4 +126,4 @@ runs:
       run: |
         # Bazelisk will download bazel to here, ensure it is cached between runs.
         export XDG_CACHE_HOME="$HOME/.cache/bazel-repo"
-        bazel --bazelrc=$GITHUB_WORKSPACE/.github/workflows/ci.bazelrc --bazelrc=.bazelrc test ${{ inputs.targetPattern }} ${{ inputs.tagFilters != '' && format('--build_tag_filters={0} --test_tag_filters={0}', inputs.tagFilters) || '' }}
+        bazel --bazelrc=$GITHUB_WORKSPACE/.github/workflows/ci.bazelrc --bazelrc=.bazelrc test ${{ inputs.targetPattern }} ${{ inputs.tagFilters != '' && format('--build_tag_filters={0} --test_tag_filters={0}', inputs.tagFilters) || '' }} ${{ inputs.bazelFlags }}

--- a/.github/actions/test/action.yaml
+++ b/.github/actions/test/action.yaml
@@ -25,6 +25,10 @@ inputs:
   tagFilters:
     description: "The Bazel build and test tag filters."
     required: true
+  remoteEnabled:
+    description: "Whether to enable remote execution."
+    default: true
+    required: false
   buildbuddyApiKey:
     description: "The API key for BuildBuddy remote cache and execution."
     required: true
@@ -53,6 +57,7 @@ runs:
           bazel-cache-${{ inputs.os }}-${{ inputs.zigVersion }}-${{ inputs.bazelVersion }}-${{ inputs.bzlmodEnabled }}-${{ inputs.folder }}-${{ inputs.targetPattern }}
 
     - name: Configure remote cache and execution
+      if: inputs.remoteEnabled
       working-directory: ${{ inputs.folder }}
       shell: bash
       env:

--- a/.github/actions/test/action.yaml
+++ b/.github/actions/test/action.yaml
@@ -22,6 +22,9 @@ inputs:
   targetPattern:
     description: "The Bazel build and test target pattern."
     required: true
+  tagFilters:
+    description: "The Bazel build and test tag filters."
+    required: true
   buildbuddyApiKey:
     description: "The API key for BuildBuddy remote cache and execution."
     required: true
@@ -45,7 +48,7 @@ runs:
         path: |
           ~/.cache/bazel
           ~/.cache/bazel-repo
-        key: bazel-cache-${{ inputs.os }}-${{ inputs.zigVersion }}-${{ inputs.bazelVersion }}-${{ inputs.bzlmodEnabled }}-${{ inputs.folder }}-${{ inputs.targetPattern }}-${{ hashFiles('**/BUILD.bazel', '**/*.bzl', '**/*.zig', 'WORKSPACE', 'WORKSPACE.bzlmod', 'MODULE.bazel') }}
+        key: bazel-cache-${{ inputs.os }}-${{ inputs.zigVersion }}-${{ inputs.bazelVersion }}-${{ inputs.bzlmodEnabled }}-${{ inputs.folder }}-${{ inputs.targetPattern }}-${{ inputs.tagFilters }}-${{ hashFiles('**/BUILD.bazel', '**/*.bzl', '**/*.zig', 'WORKSPACE', 'WORKSPACE.bzlmod', 'MODULE.bazel') }}
         restore-keys: |
           bazel-cache-${{ inputs.os }}-${{ inputs.zigVersion }}-${{ inputs.bazelVersion }}-${{ inputs.bzlmodEnabled }}-${{ inputs.folder }}-${{ inputs.targetPattern }}
 
@@ -115,4 +118,4 @@ runs:
       run: |
         # Bazelisk will download bazel to here, ensure it is cached between runs.
         export XDG_CACHE_HOME="$HOME/.cache/bazel-repo"
-        bazel --bazelrc=$GITHUB_WORKSPACE/.github/workflows/ci.bazelrc --bazelrc=.bazelrc test ${{ inputs.targetPattern }}
+        bazel --bazelrc=$GITHUB_WORKSPACE/.github/workflows/ci.bazelrc --bazelrc=.bazelrc test ${{ inputs.targetPattern }} ${{ inputs.tagFilters != '' && format('--build_tag_filters={0} --test_tag_filters={0}', inputs.tagFilters) || '' }}

--- a/.github/actions/test/action.yaml
+++ b/.github/actions/test/action.yaml
@@ -109,23 +109,6 @@ runs:
           exit 1
         }
 
-    - name: Check for test.sh
-      # Checks for the existence of test.sh in the folder. Downstream steps can use
-      # steps.has_test_sh.outputs.files_exists as a conditional.
-      id: has_test_sh
-      uses: andstor/file-existence-action@v3
-      with:
-        files: "${{ inputs.folder }}/test.sh"
-
-    - name: ./test.sh
-      # Run if there is a test.sh file in the folder
-      if: steps.has_test_sh.outputs.files_exists == 'true'
-      working-directory: ${{ inputs.folder }}
-      shell: bash
-      # Run the script potentially setting BZLMOD_FLAG=--enable_bzlmod. All test.sh
-      # scripts that run bazel directly should make use of this variable.
-      run: BZLMOD_FLAG=${{ steps.set_bzlmod_flag.outputs.bzlmod_flag }} ./test.sh
-
     - name: bazel test ${{ inputs.targetPattern }}
       working-directory: ${{ inputs.folder }}
       shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -214,6 +214,9 @@ jobs:
           zigVersion: ${{ matrix.zigVersion }}
           targetPattern: ${{ matrix.targetPattern }}
           tagFilters: ${{ matrix.tagFilters }}
+          # Disable remote execution to work around
+          # https://github.com/aherrmann/rules_zig/issues/273
+          remoteEnabled: false
           buildbuddyApiKey: ${{ secrets.BUILDBUDDY_API_KEY }}
 
   integration-tests:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -164,6 +164,56 @@ jobs:
           tagFilters: ${{ matrix.tagFilters }}
           buildbuddyApiKey: ${{ secrets.BUILDBUDDY_API_KEY }}
 
+  # Zig documentation builds are separated to work around the following issue:
+  # https://github.com/aherrmann/rules_zig/issues/273
+  test-zig-docs:
+    # The type of runner that the job will run on
+    runs-on: ${{ matrix.os }}
+
+    needs:
+      - matrix-prep-bazelversion
+      - matrix-prep-zigversion
+
+    # Run bazel test in each workspace with each version of Bazel supported
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        bazelVersion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions) }}
+        zigVersion: ${{ fromJSON(needs.matrix-prep-zigversion.outputs.zigversions) }}
+        bzlmodEnabled: [true, false]
+        folder:
+          - "."
+          - "e2e/workspace"
+        targetPattern: ["//..."]
+        tagFilters: ["+zig-docs"]
+
+    # Configure a human readable name for each job
+    name: Test ${{ matrix.targetPattern }} ${{ matrix.tagFilters }} in ${{ matrix.folder }} with Zig ${{ matrix.zigVersion }}, Bazel ${{ matrix.bazelVersion }}, and bzlmod ${{ matrix.bzlmodEnabled }} on ${{ matrix.os }}
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/test
+        with:
+          os: ${{ matrix.os }}
+          folder: ${{ matrix.folder }}
+          bazelVersion: ${{ matrix.bazelVersion }}
+          bzlmodEnabled: ${{ matrix.bzlmodEnabled }}
+          # Disable documentation generation for all but the first Bazel
+          # version, by setting --no@rules_zig//docs:build_docs in
+          # .bazelrc.user. The generated documentation can vary between Bazel
+          # versions. For example, Bazel version 7 changed the documentation of
+          # the implicit `repo_mapping` parameter to repository rules compared
+          # to Bazel version 6.
+          docsEnabled: ${{ matrix.bazelVersion == fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
+          zigVersion: ${{ matrix.zigVersion }}
+          targetPattern: ${{ matrix.targetPattern }}
+          tagFilters: ${{ matrix.tagFilters }}
+          buildbuddyApiKey: ${{ secrets.BUILDBUDDY_API_KEY }}
+
   integration-tests:
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,9 +83,10 @@ jobs:
           - "."
           - "e2e/workspace"
         targetPattern: ["//..."]
+        tagFilters: ["-zig-docs"]
 
     # Configure a human readable name for each job
-    name: Test ${{ matrix.targetPattern }} in ${{ matrix.folder }} with Zig ${{ matrix.zigVersion }}, Bazel ${{ matrix.bazelVersion }}, and bzlmod ${{ matrix.bzlmodEnabled }} on ${{ matrix.os }}
+    name: Test ${{ matrix.targetPattern }} ${{ matrix.tagFilters }} in ${{ matrix.folder }} with Zig ${{ matrix.zigVersion }}, Bazel ${{ matrix.bazelVersion }}, and bzlmod ${{ matrix.bzlmodEnabled }} on ${{ matrix.os }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -107,6 +108,7 @@ jobs:
           docsEnabled: ${{ matrix.bazelVersion == fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
           zigVersion: ${{ matrix.zigVersion }}
           targetPattern: ${{ matrix.targetPattern }}
+          tagFilters: ${{ matrix.tagFilters }}
           buildbuddyApiKey: ${{ secrets.BUILDBUDDY_API_KEY }}
 
   test-zig-versions:
@@ -130,13 +132,14 @@ jobs:
           - "."
           - "e2e/workspace"
         targetPattern: ["//..."]
+        tagFilters: ["-zig-docs"]
         exclude:
           # This combination is already tested in test-bazel-versions
           - bazelVersion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
             zigVersion: ${{ fromJSON(needs.matrix-prep-zigversion.outputs.zigversions)[0] }}
 
     # Configure a human readable name for each job
-    name: Test ${{ matrix.targetPattern }} in ${{ matrix.folder }} with Zig ${{ matrix.zigVersion }}, Bazel ${{ matrix.bazelVersion }}, and bzlmod ${{ matrix.bzlmodEnabled }} on ${{ matrix.os }}
+    name: Test ${{ matrix.targetPattern }} ${{ matrix.tagFilters }} in ${{ matrix.folder }} with Zig ${{ matrix.zigVersion }}, Bazel ${{ matrix.bazelVersion }}, and bzlmod ${{ matrix.bzlmodEnabled }} on ${{ matrix.os }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -158,6 +161,7 @@ jobs:
           docsEnabled: ${{ matrix.bazelVersion == fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
           zigVersion: ${{ matrix.zigVersion }}
           targetPattern: ${{ matrix.targetPattern }}
+          tagFilters: ${{ matrix.tagFilters }}
           buildbuddyApiKey: ${{ secrets.BUILDBUDDY_API_KEY }}
 
   integration-tests:
@@ -180,9 +184,10 @@ jobs:
         bzlmodEnabled: [true, false]
         folder: ["."]
         targetPattern: ["//zig/tests/integration_tests"]
+        tagFilters: [""]
 
     # Configure a human readable name for each job
-    name: Test ${{ matrix.targetPattern }} in ${{ matrix.folder }} with Zig ${{ matrix.zigVersion }}, Bazel ${{ matrix.bazelVersion }}, and bzlmod ${{ matrix.bzlmodEnabled }} on ${{ matrix.os }}
+    name: Test ${{ matrix.targetPattern }} ${{ matrix.tagFilters }} in ${{ matrix.folder }} with Zig ${{ matrix.zigVersion }}, Bazel ${{ matrix.bazelVersion }}, and bzlmod ${{ matrix.bzlmodEnabled }} on ${{ matrix.os }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -204,6 +209,7 @@ jobs:
           docsEnabled: ${{ matrix.bazelVersion == fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
           zigVersion: ${{ matrix.zigVersion }}
           targetPattern: ${{ matrix.targetPattern }}
+          tagFilters: ${{ matrix.tagFilters }}
           buildbuddyApiKey: ${{ secrets.BUILDBUDDY_API_KEY }}
 
   all_tests:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -214,9 +214,10 @@ jobs:
           zigVersion: ${{ matrix.zigVersion }}
           targetPattern: ${{ matrix.targetPattern }}
           tagFilters: ${{ matrix.tagFilters }}
-          # Disable remote execution to work around
+          # Disable remote execution and avoid concurrency to work around
           # https://github.com/aherrmann/rules_zig/issues/273
           remoteEnabled: false
+          bazelFlags: "--jobs=1"
           buildbuddyApiKey: ${{ secrets.BUILDBUDDY_API_KEY }}
 
   integration-tests:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -179,8 +179,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        bazelVersion: ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions) }}
-        zigVersion: ${{ fromJSON(needs.matrix-prep-zigversion.outputs.zigversions) }}
+        bazelVersion:
+          - ${{ fromJSON(needs.matrix-prep-bazelversion.outputs.bazelversions)[0] }}
+        zigVersion:
+          - ${{ fromJSON(needs.matrix-prep-zigversion.outputs.zigversions)[0] }}
         bzlmodEnabled: [true, false]
         folder:
           - "."

--- a/e2e/workspace/zig-docs/BUILD.bazel
+++ b/e2e/workspace/zig-docs/BUILD.bazel
@@ -48,18 +48,21 @@ filegroup(
     name = "binary-docs",
     srcs = [":binary"],
     output_group = "zig_docs",
+    tags = ["zig-docs"],
 )
 
 filegroup(
     name = "library-docs",
     srcs = [":library"],
     output_group = "zig_docs",
+    tags = ["zig-docs"],
 )
 
 filegroup(
     name = "shared-library-docs",
     srcs = [":shared-library"],
     output_group = "zig_docs",
+    tags = ["zig-docs"],
 )
 
 filegroup(
@@ -67,6 +70,7 @@ filegroup(
     testonly = True,
     srcs = [":test"],
     output_group = "zig_docs",
+    tags = ["zig-docs"],
 )
 
 copy_file(
@@ -75,8 +79,10 @@ copy_file(
         name = "binary-docs-index",
         directory = ":binary-docs",
         path = "index.html",
+        tags = ["zig-docs"],
     ),
     out = "binary-docs-index-copy.html",
+    tags = ["zig-docs"],
 )
 
 copy_file(
@@ -85,8 +91,10 @@ copy_file(
         name = "library-docs-index",
         directory = ":library-docs",
         path = "index.html",
+        tags = ["zig-docs"],
     ),
     out = "library-docs-index-copy.html",
+    tags = ["zig-docs"],
 )
 
 copy_file(
@@ -95,8 +103,10 @@ copy_file(
         name = "shared-library-docs-index",
         directory = ":shared-library-docs",
         path = "index.html",
+        tags = ["zig-docs"],
     ),
     out = "shared-library-docs-index-copy.html",
+    tags = ["zig-docs"],
 )
 
 copy_file(
@@ -107,12 +117,15 @@ copy_file(
         testonly = True,
         directory = ":test-docs",
         path = "index.html",
+        tags = ["zig-docs"],
     ),
     out = "test-docs-index-copy.html",
+    tags = ["zig-docs"],
 )
 
 build_test(
     name = "zig-docs",
+    tags = ["zig-docs"],
     targets = [
         ":binary-docs-index-copy",
         ":library-docs-index-copy",

--- a/e2e/workspace/zig-docs/BUILD.bazel
+++ b/e2e/workspace/zig-docs/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
 load("@aspect_bazel_lib//lib:directory_path.bzl", "make_directory_path")
+load("@bazel_skylib//lib:selects.bzl", "selects")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load(
     "@rules_zig//zig:defs.bzl",
@@ -12,6 +13,14 @@ load(
 )
 load("@rules_zig//zig/private:versions.bzl", "TOOL_VERSIONS")
 
+selects.config_setting_group(
+    name = "macos-zig-0.12.0",
+    match_all = [
+        "@platforms//os:macos",
+        "@zig_toolchains//:0.12.0",
+    ],
+)
+
 zig_module(
     name = "hello_world",
     main = "hello_world.zig",
@@ -21,6 +30,10 @@ zig_binary(
     name = "binary",
     extra_docs = ["guide.md"],
     main = "main.zig",
+    target_compatible_with = select({
+        ":macos-zig-0.12.0": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
     deps = [":hello_world"],
 )
 
@@ -28,6 +41,10 @@ zig_library(
     name = "library",
     extra_docs = ["guide.md"],
     main = "main.zig",
+    target_compatible_with = select({
+        ":macos-zig-0.12.0": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
     deps = [":hello_world"],
 )
 
@@ -35,6 +52,10 @@ zig_shared_library(
     name = "shared-library",
     extra_docs = ["guide.md"],
     main = "main.zig",
+    target_compatible_with = select({
+        ":macos-zig-0.12.0": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
     deps = [":hello_world"],
 )
 
@@ -43,6 +64,10 @@ zig_test(
     size = "small",
     extra_docs = ["guide.md"],
     main = "main.zig",
+    target_compatible_with = select({
+        ":macos-zig-0.12.0": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
     deps = [":hello_world"],
 )
 

--- a/e2e/workspace/zig-docs/BUILD.bazel
+++ b/e2e/workspace/zig-docs/BUILD.bazel
@@ -4,11 +4,13 @@ load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load(
     "@rules_zig//zig:defs.bzl",
     "zig_binary",
+    "zig_configure_test",
     "zig_library",
     "zig_module",
     "zig_shared_library",
     "zig_test",
 )
+load("@rules_zig//zig/private:versions.bzl", "TOOL_VERSIONS")
 
 zig_module(
     name = "hello_world",
@@ -133,3 +135,14 @@ build_test(
         ":test-docs-index-copy",
     ],
 )
+
+[
+    zig_configure_test(
+        name = "zig-docs-{}".format(version),
+        size = "small",
+        actual = ":zig-docs",
+        tags = ["zig-docs"],
+        zig_version = version,
+    )
+    for version in TOOL_VERSIONS.keys()
+]

--- a/zig/runfiles/BUILD.bazel
+++ b/zig/runfiles/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_skylib//lib:selects.bzl", "selects")
 load(
     "@rules_zig//zig:defs.bzl",
     "zig_library",
@@ -13,6 +14,14 @@ _SRCS = [
     "src/RPath.zig",
     "src/Runfiles.zig",
 ]
+
+selects.config_setting_group(
+    name = "macos-zig-0.12.0",
+    match_all = [
+        "@platforms//os:macos",
+        "@zig_toolchains//:0.12.0",
+    ],
+)
 
 zig_module(
     name = "runfiles",
@@ -44,6 +53,10 @@ filegroup(
     srcs = [":lib"],
     output_group = "zig_docs",
     tags = ["zig-docs"],
+    target_compatible_with = select({
+        ":macos-zig-0.12.0": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
     visibility = ["//visibility:public"],
 )
 

--- a/zig/runfiles/BUILD.bazel
+++ b/zig/runfiles/BUILD.bazel
@@ -43,6 +43,7 @@ filegroup(
     name = "docs",
     srcs = [":lib"],
     output_group = "zig_docs",
+    tags = ["zig-docs"],
     visibility = ["//visibility:public"],
 )
 

--- a/zig/tests/zig-docs/BUILD.bazel
+++ b/zig/tests/zig-docs/BUILD.bazel
@@ -1,4 +1,6 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@rules_zig//zig:defs.bzl", "zig_configure_test")
+load("//zig/private:versions.bzl", "TOOL_VERSIONS")
 
 build_test(
     name = "zig-docs",
@@ -7,3 +9,14 @@ build_test(
         "//zig/runfiles:docs",
     ],
 )
+
+[
+    zig_configure_test(
+        name = "zig-docs-{}".format(version),
+        size = "small",
+        actual = ":zig-docs",
+        tags = ["zig-docs"],
+        zig_version = version,
+    )
+    for version in TOOL_VERSIONS.keys()
+]

--- a/zig/tests/zig-docs/BUILD.bazel
+++ b/zig/tests/zig-docs/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+
+build_test(
+    name = "zig-docs",
+    tags = ["zig-docs"],
+    targets = [
+        "//zig/runfiles:docs",
+    ],
+)


### PR DESCRIPTION
Zig docs builds frequently failed on CI, see #273. Two cases were observed:

1. Zig docs builds failed when remote execution was enabled.
2. Zig docs builds failed locally on MacOS with Zig version 0.12.0.

The first case is addressed by moving Zig docs build tests into a separate CI job and disabling remote execution in that case.
The second case is addressed by marking Zig docs targets as incompatible with Zig version 0.12.0 and MacOS systems.

This is a workaround, not a proper fix of #273.

- **Remove test.sh check from CI script**
- **Tag all Zig documentation targets**
- **Use tag filters to skip Zig docs builds**
- **Add separate Zig docs tests**
- **Exclude zig-docs in presubmit.yml**
- **build_test target for runfiles docs**
- **Zig docs tests for all Zig versions using transitions**
- **Reduce zig-docs CI matrix**
- **Disable remote execution on Zig docs tests**
- **Avoid parallelism for Zig docs builds**
- **Skip Zig docs on MacOS with Zig 0.12.0**
