### PR TITLE
feat: Add compiler_runtime attribute to control -fcompiler-rt

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -13,8 +13,8 @@ the current target name or current repository name.
 <pre>
 load("@rules_zig//zig:defs.bzl", "zig_binary")
 
-zig_binary(<a href="#zig_binary-name">name</a>, <a href="#zig_binary-deps">deps</a>, <a href="#zig_binary-srcs">srcs</a>, <a href="#zig_binary-data">data</a>, <a href="#zig_binary-cdeps">cdeps</a>, <a href="#zig_binary-copts">copts</a>, <a href="#zig_binary-csrcs">csrcs</a>, <a href="#zig_binary-env">env</a>, <a href="#zig_binary-extra_docs">extra_docs</a>, <a href="#zig_binary-extra_srcs">extra_srcs</a>, <a href="#zig_binary-linker_script">linker_script</a>,
-           <a href="#zig_binary-main">main</a>)
+zig_binary(<a href="#zig_binary-name">name</a>, <a href="#zig_binary-deps">deps</a>, <a href="#zig_binary-srcs">srcs</a>, <a href="#zig_binary-data">data</a>, <a href="#zig_binary-cdeps">cdeps</a>, <a href="#zig_binary-compiler_runtime">compiler_runtime</a>, <a href="#zig_binary-copts">copts</a>, <a href="#zig_binary-csrcs">csrcs</a>, <a href="#zig_binary-env">env</a>, <a href="#zig_binary-extra_docs">extra_docs</a>,
+           <a href="#zig_binary-extra_srcs">extra_srcs</a>, <a href="#zig_binary-linker_script">linker_script</a>, <a href="#zig_binary-main">main</a>)
 </pre>
 
 Builds a Zig binary.
@@ -52,6 +52,7 @@ zig_binary(
 | <a id="zig_binary-srcs"></a>srcs |  Other Zig source files required to build the target, e.g. files imported using `@import`.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="zig_binary-data"></a>data |  Files required by the target during runtime.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="zig_binary-cdeps"></a>cdeps |  C dependencies providing headers to include and libraries to link against, typically `cc_library` targets.<br><br>Note, if you need to include C or C++ standard library headers and encounter errors of the following form:<br><br><pre><code>note: libc headers not available; compilation does not link against libc&#10;error: 'math.h' file not found</code></pre><br><br>Then you may need to list `@rules_zig//zig/lib:libc` or `@rules_zig//zig/lib:libc++` in this attribute.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="zig_binary-compiler_runtime"></a>compiler_runtime |  Whether to include Zig compiler runtime symbols in the generated output. The default behavior is to include them in executables and shared libraries.   | String | optional |  `"default"`  |
 | <a id="zig_binary-copts"></a>copts |  C compiler flags required to build the C sources of the target. Subject to location expansion.   | List of strings | optional |  `[]`  |
 | <a id="zig_binary-csrcs"></a>csrcs |  C source files required to build the target.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="zig_binary-env"></a>env |  Additional environment variables to set when executed by `bazel run`. Subject to location expansion. NOTE: The environment variables are not set when you run the target outside of Bazel (for example, by manually executing the binary in bazel-bin/).   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
@@ -257,8 +258,8 @@ zig_configure_test(
 <pre>
 load("@rules_zig//zig:defs.bzl", "zig_library")
 
-zig_library(<a href="#zig_library-name">name</a>, <a href="#zig_library-deps">deps</a>, <a href="#zig_library-srcs">srcs</a>, <a href="#zig_library-data">data</a>, <a href="#zig_library-cdeps">cdeps</a>, <a href="#zig_library-copts">copts</a>, <a href="#zig_library-csrcs">csrcs</a>, <a href="#zig_library-extra_docs">extra_docs</a>, <a href="#zig_library-extra_srcs">extra_srcs</a>, <a href="#zig_library-linker_script">linker_script</a>,
-            <a href="#zig_library-main">main</a>)
+zig_library(<a href="#zig_library-name">name</a>, <a href="#zig_library-deps">deps</a>, <a href="#zig_library-srcs">srcs</a>, <a href="#zig_library-data">data</a>, <a href="#zig_library-cdeps">cdeps</a>, <a href="#zig_library-compiler_runtime">compiler_runtime</a>, <a href="#zig_library-copts">copts</a>, <a href="#zig_library-csrcs">csrcs</a>, <a href="#zig_library-extra_docs">extra_docs</a>, <a href="#zig_library-extra_srcs">extra_srcs</a>,
+            <a href="#zig_library-linker_script">linker_script</a>, <a href="#zig_library-main">main</a>)
 </pre>
 
 Builds a Zig library.
@@ -295,6 +296,7 @@ zig_library(
 | <a id="zig_library-srcs"></a>srcs |  Other Zig source files required to build the target, e.g. files imported using `@import`.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="zig_library-data"></a>data |  Files required by the target during runtime.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="zig_library-cdeps"></a>cdeps |  C dependencies providing headers to include and libraries to link against, typically `cc_library` targets.<br><br>Note, if you need to include C or C++ standard library headers and encounter errors of the following form:<br><br><pre><code>note: libc headers not available; compilation does not link against libc&#10;error: 'math.h' file not found</code></pre><br><br>Then you may need to list `@rules_zig//zig/lib:libc` or `@rules_zig//zig/lib:libc++` in this attribute.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="zig_library-compiler_runtime"></a>compiler_runtime |  Whether to include Zig compiler runtime symbols in the generated output. The default behavior is to include them in executables and shared libraries.   | String | optional |  `"default"`  |
 | <a id="zig_library-copts"></a>copts |  C compiler flags required to build the C sources of the target. Subject to location expansion.   | List of strings | optional |  `[]`  |
 | <a id="zig_library-csrcs"></a>csrcs |  C source files required to build the target.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="zig_library-extra_docs"></a>extra_docs |  Other files required to generate documentation, e.g. guides referenced using `//!zig-autodoc-guide:`.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
@@ -359,8 +361,8 @@ zig_module(
 <pre>
 load("@rules_zig//zig:defs.bzl", "zig_shared_library")
 
-zig_shared_library(<a href="#zig_shared_library-name">name</a>, <a href="#zig_shared_library-deps">deps</a>, <a href="#zig_shared_library-srcs">srcs</a>, <a href="#zig_shared_library-data">data</a>, <a href="#zig_shared_library-cdeps">cdeps</a>, <a href="#zig_shared_library-copts">copts</a>, <a href="#zig_shared_library-csrcs">csrcs</a>, <a href="#zig_shared_library-extra_docs">extra_docs</a>, <a href="#zig_shared_library-extra_srcs">extra_srcs</a>,
-                   <a href="#zig_shared_library-linker_script">linker_script</a>, <a href="#zig_shared_library-main">main</a>)
+zig_shared_library(<a href="#zig_shared_library-name">name</a>, <a href="#zig_shared_library-deps">deps</a>, <a href="#zig_shared_library-srcs">srcs</a>, <a href="#zig_shared_library-data">data</a>, <a href="#zig_shared_library-cdeps">cdeps</a>, <a href="#zig_shared_library-compiler_runtime">compiler_runtime</a>, <a href="#zig_shared_library-copts">copts</a>, <a href="#zig_shared_library-csrcs">csrcs</a>, <a href="#zig_shared_library-extra_docs">extra_docs</a>,
+                   <a href="#zig_shared_library-extra_srcs">extra_srcs</a>, <a href="#zig_shared_library-linker_script">linker_script</a>, <a href="#zig_shared_library-main">main</a>)
 </pre>
 
 Builds a Zig shared library.
@@ -394,6 +396,7 @@ zig_shared_library(
 | <a id="zig_shared_library-srcs"></a>srcs |  Other Zig source files required to build the target, e.g. files imported using `@import`.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="zig_shared_library-data"></a>data |  Files required by the target during runtime.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="zig_shared_library-cdeps"></a>cdeps |  C dependencies providing headers to include and libraries to link against, typically `cc_library` targets.<br><br>Note, if you need to include C or C++ standard library headers and encounter errors of the following form:<br><br><pre><code>note: libc headers not available; compilation does not link against libc&#10;error: 'math.h' file not found</code></pre><br><br>Then you may need to list `@rules_zig//zig/lib:libc` or `@rules_zig//zig/lib:libc++` in this attribute.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="zig_shared_library-compiler_runtime"></a>compiler_runtime |  Whether to include Zig compiler runtime symbols in the generated output. The default behavior is to include them in executables and shared libraries.   | String | optional |  `"default"`  |
 | <a id="zig_shared_library-copts"></a>copts |  C compiler flags required to build the C sources of the target. Subject to location expansion.   | List of strings | optional |  `[]`  |
 | <a id="zig_shared_library-csrcs"></a>csrcs |  C source files required to build the target.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="zig_shared_library-extra_docs"></a>extra_docs |  Other files required to generate documentation, e.g. guides referenced using `//!zig-autodoc-guide:`.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
@@ -409,8 +412,8 @@ zig_shared_library(
 <pre>
 load("@rules_zig//zig:defs.bzl", "zig_test")
 
-zig_test(<a href="#zig_test-name">name</a>, <a href="#zig_test-deps">deps</a>, <a href="#zig_test-srcs">srcs</a>, <a href="#zig_test-data">data</a>, <a href="#zig_test-cdeps">cdeps</a>, <a href="#zig_test-copts">copts</a>, <a href="#zig_test-csrcs">csrcs</a>, <a href="#zig_test-env">env</a>, <a href="#zig_test-env_inherit">env_inherit</a>, <a href="#zig_test-extra_docs">extra_docs</a>, <a href="#zig_test-extra_srcs">extra_srcs</a>,
-         <a href="#zig_test-linker_script">linker_script</a>, <a href="#zig_test-main">main</a>)
+zig_test(<a href="#zig_test-name">name</a>, <a href="#zig_test-deps">deps</a>, <a href="#zig_test-srcs">srcs</a>, <a href="#zig_test-data">data</a>, <a href="#zig_test-cdeps">cdeps</a>, <a href="#zig_test-compiler_runtime">compiler_runtime</a>, <a href="#zig_test-copts">copts</a>, <a href="#zig_test-csrcs">csrcs</a>, <a href="#zig_test-env">env</a>, <a href="#zig_test-env_inherit">env_inherit</a>,
+         <a href="#zig_test-extra_docs">extra_docs</a>, <a href="#zig_test-extra_srcs">extra_srcs</a>, <a href="#zig_test-linker_script">linker_script</a>, <a href="#zig_test-main">main</a>)
 </pre>
 
 Builds a Zig test.
@@ -447,6 +450,7 @@ zig_test(
 | <a id="zig_test-srcs"></a>srcs |  Other Zig source files required to build the target, e.g. files imported using `@import`.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="zig_test-data"></a>data |  Files required by the target during runtime.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="zig_test-cdeps"></a>cdeps |  C dependencies providing headers to include and libraries to link against, typically `cc_library` targets.<br><br>Note, if you need to include C or C++ standard library headers and encounter errors of the following form:<br><br><pre><code>note: libc headers not available; compilation does not link against libc&#10;error: 'math.h' file not found</code></pre><br><br>Then you may need to list `@rules_zig//zig/lib:libc` or `@rules_zig//zig/lib:libc++` in this attribute.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="zig_test-compiler_runtime"></a>compiler_runtime |  Whether to include Zig compiler runtime symbols in the generated output. The default behavior is to include them in executables and shared libraries.   | String | optional |  `"default"`  |
 | <a id="zig_test-copts"></a>copts |  C compiler flags required to build the C sources of the target. Subject to location expansion.   | List of strings | optional |  `[]`  |
 | <a id="zig_test-csrcs"></a>csrcs |  C source files required to build the target.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="zig_test-env"></a>env |  Additional environment variables to set when executed by `bazel run` or `bazel test`. Subject to location expansion.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |

--- a/zig/private/common/zig_build.bzl
+++ b/zig/private/common/zig_build.bzl
@@ -90,6 +90,15 @@ Then you may need to list `@rules_zig//zig/lib:libc` or `@rules_zig//zig/lib:lib
         mandatory = False,
         providers = [CcInfo],
     ),
+    "compiler_runtime": attr.string(
+        doc = """\
+Whether to include Zig compiler runtime symbols in the generated output.
+The default behavior is to include them in executables and shared libraries.
+""",
+        mandatory = False,
+        values = ["exclude", "include", "default"],
+        default = "default",
+    ),
     "linker_script": attr.label(
         doc = "Custom linker script for the target.",
         allow_single_file = True,
@@ -234,6 +243,11 @@ def zig_build_impl(ctx, *, kind):
         solib_parents = [""]
     else:
         fail("Unknown rule kind '{}'.".format(kind))
+
+    if ctx.attr.compiler_runtime == "include":
+        args.add("-fcompiler-rt")
+    elif ctx.attr.compiler_runtime == "exclude":
+        args.add("-fno-compiler-rt")
 
     cc_info = None
     if library_to_link != None:

--- a/zig/tests/compiler_runtime/BUILD.bazel
+++ b/zig/tests/compiler_runtime/BUILD.bazel
@@ -1,0 +1,35 @@
+load(
+    "@rules_zig//zig:defs.bzl",
+    "zig_binary",
+    "zig_library",
+    "zig_shared_library",
+    "zig_test",
+)
+
+zig_binary(
+    name = "binary",
+    main = "main.zig",
+    visibility = ["//zig/tests:__pkg__"],
+)
+
+zig_library(
+    name = "library-default",
+    compiler_runtime = "default",
+    main = "main.zig",
+    visibility = ["//zig/tests:__pkg__"],
+)
+
+zig_shared_library(
+    name = "shared-library-exclude",
+    compiler_runtime = "exclude",
+    main = "main.zig",
+    visibility = ["//zig/tests:__pkg__"],
+)
+
+zig_test(
+    name = "test-include",
+    size = "small",
+    compiler_runtime = "include",
+    main = "main.zig",
+    visibility = ["//zig/tests:__pkg__"],
+)

--- a/zig/tests/compiler_runtime/BUILD.bazel
+++ b/zig/tests/compiler_runtime/BUILD.bazel
@@ -13,15 +13,15 @@ zig_binary(
 )
 
 zig_library(
-    name = "library-default",
-    compiler_runtime = "default",
+    name = "library-exclude",
+    compiler_runtime = "exclude",
     main = "main.zig",
     visibility = ["//zig/tests:__pkg__"],
 )
 
 zig_shared_library(
-    name = "shared-library-exclude",
-    compiler_runtime = "exclude",
+    name = "shared-library-default",
+    compiler_runtime = "default",
     main = "main.zig",
     visibility = ["//zig/tests:__pkg__"],
 )

--- a/zig/tests/compiler_runtime/main.zig
+++ b/zig/tests/compiler_runtime/main.zig
@@ -1,0 +1,15 @@
+const std = @import("std");
+
+export fn sayHello() void {
+    std.io.getStdOut().writeAll(
+        "Hello World!\n",
+    ) catch unreachable;
+}
+
+pub fn main() void {
+    sayHello();
+}
+
+test "test" {
+    try std.testing.expectEqual(2, 1 + 1);
+}

--- a/zig/tests/rules_test.bzl
+++ b/zig/tests/rules_test.bzl
@@ -309,15 +309,15 @@ def _test_compiler_runtime(name):
         size = "small",
     )
     _compiler_runtime_test(
-        name = name + "-library-default",
-        target_under_test = "//zig/tests/compiler_runtime:library-default",
-        compiler_runtime = "default",
+        name = name + "-library-exclude",
+        target_under_test = "//zig/tests/compiler_runtime:library-exclude",
+        compiler_runtime = "exclude",
         size = "small",
     )
     _compiler_runtime_test(
-        name = name + "-shared-library-exclude",
-        target_under_test = "//zig/tests/compiler_runtime:shared-library-exclude",
-        compiler_runtime = "exclude",
+        name = name + "-shared-library-default",
+        target_under_test = "//zig/tests/compiler_runtime:shared-library-default",
+        compiler_runtime = "default",
         size = "small",
     )
     _compiler_runtime_test(
@@ -328,8 +328,8 @@ def _test_compiler_runtime(name):
     )
     return [
         name + "-binary",
-        name + "-library-default",
-        name + "-shared-library-exclude",
+        name + "-library-exclude",
+        name + "-shared-library-default",
         name + "-test-include",
     ]
 

--- a/zig/tests/rules_test.bzl
+++ b/zig/tests/rules_test.bzl
@@ -7,6 +7,7 @@ load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
 load(
     ":util.bzl",
     "assert_find_unique_surrounded_arguments",
+    "assert_flag_set",
     "assert_flag_unset",
 )
 
@@ -270,6 +271,68 @@ def _test_c_sources_binary(name):
     )
     return [":" + name + "_with_copts", ":" + name + "_without_copts"]
 
+def _compiler_runtime_test_impl(ctx):
+    env = analysistest.begin(ctx)
+
+    build = [
+        action
+        for action in analysistest.target_actions(env)
+        if action.mnemonic in ["ZigBuildExe", "ZigBuildTest", "ZigBuildLib", "ZigBuildSharedLib"]
+    ]
+    asserts.equals(env, 1, len(build), "Target should have one ZigBuild* action.")
+    build = build[0]
+
+    if ctx.attr.compiler_runtime == "include":
+        assert_flag_set(env, "-fcompiler-rt", build.argv)
+        assert_flag_unset(env, "-fno-compiler-rt", build.argv)
+    elif ctx.attr.compiler_runtime == "exclude":
+        assert_flag_set(env, "-fno-compiler-rt", build.argv)
+        assert_flag_unset(env, "-fcompiler-rt", build.argv)
+    else:
+        assert_flag_unset(env, "-fcompiler-rt", build.argv)
+        assert_flag_unset(env, "-fno-compiler-rt", build.argv)
+
+    return analysistest.end(env)
+
+_compiler_runtime_test = analysistest.make(
+    _compiler_runtime_test_impl,
+    attrs = {
+        "compiler_runtime": attr.string(mandatory = False),
+    },
+)
+
+def _test_compiler_runtime(name):
+    _compiler_runtime_test(
+        name = name + "-binary",
+        target_under_test = "//zig/tests/compiler_runtime:binary",
+        compiler_runtime = None,
+        size = "small",
+    )
+    _compiler_runtime_test(
+        name = name + "-library-default",
+        target_under_test = "//zig/tests/compiler_runtime:library-default",
+        compiler_runtime = "default",
+        size = "small",
+    )
+    _compiler_runtime_test(
+        name = name + "-shared-library-exclude",
+        target_under_test = "//zig/tests/compiler_runtime:shared-library-exclude",
+        compiler_runtime = "exclude",
+        size = "small",
+    )
+    _compiler_runtime_test(
+        name = name + "-test-include",
+        target_under_test = "//zig/tests/compiler_runtime:test-include",
+        compiler_runtime = "include",
+        size = "small",
+    )
+    return [
+        name + "-binary",
+        name + "-library-default",
+        name + "-shared-library-exclude",
+        name + "-test-include",
+    ]
+
 def rules_test_suite(name):
     """Generate test suite and test targets for common rule analysis tests.
 
@@ -283,6 +346,7 @@ def rules_test_suite(name):
     tests += _test_multiple_sources_binary(name = "multiple_sources_binary_test")
     tests += _test_module_binary(name = "module_binary_test")
     tests += _test_c_sources_binary(name = "c_sources_binary_test")
+    tests += _test_compiler_runtime(name = "compiler_runtime_test")
     native.test_suite(
         name = name,
         tests = tests,


### PR DESCRIPTION
The `compiler_runtime` attribute accepts the values
- "include" to pass "-fcompiler-rt",
- "exclude" to pass "-fno-compiler-rt", and
- "default" to rely on the Zig compiler's default.

---

- **feat: Add compiler_runtime attribute to control -fcompiler-rt**
- **compiler_runtime test targets**
- **Analysistests for compiler_runtime attribute**
