### PR TITLE
feat!: drop Bazel 7 support, Bazel 8 supported

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform: ["ubuntu2204", "macos"] # ["windows"]
-  bazel: [7.x, 8.x]
+  bazel: [8.x]
 tasks:
   run_tests:
     name: "Run tests"
@@ -14,7 +14,7 @@ bcr_test_module:
   module_path: "e2e/workspace"
   matrix:
     platform: ["ubuntu2204", "macos"] # ["windows"]
-    bazel: [7.x, 8.x]
+    bazel: [8.x]
   tasks:
     run_tests:
       name: "Run test module"

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -62,13 +62,11 @@ bazel_binaries = use_extension(
     dev_dependency = True,
 )
 bazel_binaries.download(version_file = "//:.bazelversion")
-bazel_binaries.download(version = "7.1.0")
 use_repo(
     bazel_binaries,
     "bazel_binaries",
     "bazel_binaries_bazelisk",
     "build_bazel_bazel_.bazelversion",
-    "build_bazel_bazel_7_1_0",
 )
 
 # TODO[AH] Should be an implicit transitive dependency through rules_bazel_integration_test.


### PR DESCRIPTION
BREAKING CHANGE: Bazel version 7 is no longer supported, use Bazel 8.
