### PR TITLE
feat: support Bazel 9 pre-release

### DIFF
--- a/.bazelversion
+++ b/.bazelversion
@@ -1,4 +1,4 @@
-9.0.0-pre.20250805.4
+9.0.0-pre.20250831.1
 # The first line of this file is used by Bazelisk and Bazel to be sure
 # the right version of Bazel is used to build and test this repo.
 # This also defines which version is used on CI.

--- a/.bazelversion
+++ b/.bazelversion
@@ -1,4 +1,4 @@
-9.0.0-pre.20250730.2
+9.0.0-pre.20250805.4
 # The first line of this file is used by Bazelisk and Bazel to be sure
 # the right version of Bazel is used to build and test this repo.
 # This also defines which version is used on CI.

--- a/.bazelversion
+++ b/.bazelversion
@@ -1,4 +1,4 @@
-8.4.1
+9.0.0-pre.20250730.2
 # The first line of this file is used by Bazelisk and Bazel to be sure
 # the right version of Bazel is used to build and test this repo.
 # This also defines which version is used on CI.

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -3,6 +3,13 @@ exports_files(
     visibility = ["//util:__pkg__"],
 )
 
+exports_files(
+    [".bazelversion"],
+    # Note, do not depend on this outside of rules_zig.
+    # It is only exported for write_source_files in e2e/workspace/BUILD.
+    visibility = ["//visibility:public"],
+)
+
 filegroup(
     name = "bazelrc",
     srcs = [

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -30,6 +30,7 @@ filegroup(
 filegroup(
     name = "all_files",
     srcs = [
+        ":.bazelversion",
         ":BUILD.bazel",
         ":MODULE.bazel",
         ":WORKSPACE",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -62,11 +62,13 @@ bazel_binaries = use_extension(
     dev_dependency = True,
 )
 bazel_binaries.download(version_file = "//:.bazelversion")
+bazel_binaries.download(version = "8.4.1")
 use_repo(
     bazel_binaries,
     "bazel_binaries",
     "bazel_binaries_bazelisk",
     "build_bazel_bazel_.bazelversion",
+    "build_bazel_bazel_8_4_1",
 )
 
 # TODO[AH] Should be an implicit transitive dependency through rules_bazel_integration_test.

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -40,6 +40,7 @@ buildbuddy = use_extension(
 )
 use_repo(buildbuddy, "buildbuddy_toolchain")
 
+bazel_dep(name = "bazel_features", version = "1.35.0", dev_dependency = True)
 bazel_dep(name = "stardoc", version = "0.8.0", dev_dependency = True)
 bazel_dep(name = "gazelle", version = "0.45.0", dev_dependency = True, repo_name = "bazel_gazelle")
 bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.8.1", dev_dependency = True)

--- a/e2e/workspace/.bazelversion
+++ b/e2e/workspace/.bazelversion
@@ -1,4 +1,4 @@
-9.0.0-pre.20250805.4
+9.0.0-pre.20250831.1
 # The first line of this file is used by Bazelisk and Bazel to be sure
 # the right version of Bazel is used to build and test this repo.
 # This also defines which version is used on CI.

--- a/e2e/workspace/.bazelversion
+++ b/e2e/workspace/.bazelversion
@@ -1,4 +1,4 @@
-9.0.0-pre.20250730.2
+9.0.0-pre.20250805.4
 # The first line of this file is used by Bazelisk and Bazel to be sure
 # the right version of Bazel is used to build and test this repo.
 # This also defines which version is used on CI.

--- a/e2e/workspace/.bazelversion
+++ b/e2e/workspace/.bazelversion
@@ -1,0 +1,7 @@
+9.0.0-pre.20250730.2
+# The first line of this file is used by Bazelisk and Bazel to be sure
+# the right version of Bazel is used to build and test this repo.
+# This also defines which version is used on CI.
+#
+# Note that you should also run integration_tests against other Bazel
+# versions you support.

--- a/e2e/workspace/BUILD
+++ b/e2e/workspace/BUILD
@@ -1,0 +1,8 @@
+load("@aspect_bazel_lib//lib:write_source_files.bzl", "write_source_files")
+
+write_source_files(
+    name = "write_bazelversion",
+    files = {
+        ".bazelversion": "@rules_zig//:.bazelversion",
+    },
+)

--- a/e2e/workspace/MODULE.bazel
+++ b/e2e/workspace/MODULE.bazel
@@ -1,5 +1,6 @@
 bazel_dep(name = "rules_zig", version = "0.6.1", dev_dependency = True)
 bazel_dep(name = "aspect_bazel_lib", version = "2.21.1", dev_dependency = True)
+bazel_dep(name = "bazel_features", version = "1.35.0", dev_dependency = True)
 bazel_dep(name = "bazel_skylib", version = "1.8.1", dev_dependency = True)
 bazel_dep(name = "platforms", version = "1.0.0", dev_dependency = True)
 bazel_dep(name = "rules_cc", version = "0.2.5", dev_dependency = True)

--- a/e2e/workspace/configure-target/BUILD.bazel
+++ b/e2e/workspace/configure-target/BUILD.bazel
@@ -7,6 +7,7 @@ load(
     "zig_configure_test",
     "zig_test",
 )
+load(":defs.bzl", "empty_toolchain")
 
 platform(
     name = "aarch64-linux",
@@ -22,6 +23,14 @@ platform(
         "@platforms//os:windows",
         "@platforms//cpu:x86_64",
     ],
+)
+
+empty_toolchain(name = "empty_toolchain")
+
+toolchain(
+    name = "unconstrained_default_test_toolchain",
+    toolchain = ":empty_toolchain",
+    toolchain_type = "@bazel_tools//tools/test:default_test_toolchain_type",
 )
 
 zig_binary(
@@ -116,6 +125,7 @@ zig_test(
 zig_configure_test(
     name = "test_aarch64-linux",
     actual = ":test",
+    extra_toolchains = [":unconstrained_default_test_toolchain"],
     tags = ["manual"],
     target = ":aarch64-linux",
 )
@@ -123,6 +133,7 @@ zig_configure_test(
 zig_configure_test(
     name = "test_x86_64-windows",
     actual = ":test",
+    extra_toolchains = [":unconstrained_default_test_toolchain"],
     tags = ["manual"],
     target = ":x86_64-windows",
 )

--- a/e2e/workspace/configure-target/BUILD.bazel
+++ b/e2e/workspace/configure-target/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_features//:features.bzl", "bazel_features")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
 load(
@@ -29,6 +30,7 @@ empty_toolchain(name = "empty_toolchain")
 
 toolchain(
     name = "unconstrained_default_test_toolchain",
+    target_compatible_with = [] if bazel_features.toolchains.has_default_test_toolchain_type else ["@platforms//:incompatible"],
     toolchain = ":empty_toolchain",
     toolchain_type = "@bazel_tools//tools/test:default_test_toolchain_type",
 )
@@ -125,7 +127,7 @@ zig_test(
 zig_configure_test(
     name = "test_aarch64-linux",
     actual = ":test",
-    extra_toolchains = [":unconstrained_default_test_toolchain"],
+    extra_toolchains = [":unconstrained_default_test_toolchain"] if bazel_features.toolchains.has_default_test_toolchain_type else [],
     tags = ["manual"],
     target = ":aarch64-linux",
 )
@@ -133,7 +135,7 @@ zig_configure_test(
 zig_configure_test(
     name = "test_x86_64-windows",
     actual = ":test",
-    extra_toolchains = [":unconstrained_default_test_toolchain"],
+    extra_toolchains = [":unconstrained_default_test_toolchain"] if bazel_features.toolchains.has_default_test_toolchain_type else [],
     tags = ["manual"],
     target = ":x86_64-windows",
 )

--- a/e2e/workspace/configure-target/defs.bzl
+++ b/e2e/workspace/configure-target/defs.bzl
@@ -1,0 +1,5 @@
+"""Helper rules and functions for target configuration tests."""
+
+empty_toolchain = rule(
+    implementation = lambda ctx: platform_common.ToolchainInfo(),
+)

--- a/zig/private/resolved_target_toolchain.bzl
+++ b/zig/private/resolved_target_toolchain.bzl
@@ -22,6 +22,5 @@ def _resolved_target_toolchain_impl(ctx):
 resolved_target_toolchain = rule(
     implementation = _resolved_target_toolchain_impl,
     toolchains = ["//zig/target:toolchain_type"],
-    incompatible_use_toolchain_transition = True,
     doc = DOC,
 )

--- a/zig/private/resolved_toolchain.bzl
+++ b/zig/private/resolved_toolchain.bzl
@@ -22,6 +22,5 @@ def _resolved_toolchain_impl(ctx):
 resolved_toolchain = rule(
     implementation = _resolved_toolchain_impl,
     toolchains = ["//zig:toolchain_type"],
-    incompatible_use_toolchain_transition = True,
     doc = DOC,
 )

--- a/zig/tests/platforms/BUILD.bazel
+++ b/zig/tests/platforms/BUILD.bazel
@@ -1,6 +1,7 @@
 """Target platforms used for testing purposes."""
 
 load("//zig:toolchain.bzl", "zig_target_toolchain")
+load(":defs.bzl", "empty_toolchain")
 
 platform(
     name = "x86_64-linux",
@@ -118,4 +119,12 @@ toolchain(
     ],
     toolchain = ":zig-only-x86_64-linux_target_toolchain",
     toolchain_type = "//zig/target:toolchain_type",
+)
+
+empty_toolchain(name = "empty_toolchain")
+
+toolchain(
+    name = "unconstrained_default_test_toolchain",
+    toolchain = ":empty_toolchain",
+    toolchain_type = "@bazel_tools//tools/test:default_test_toolchain_type",
 )

--- a/zig/tests/platforms/BUILD.bazel
+++ b/zig/tests/platforms/BUILD.bazel
@@ -1,5 +1,6 @@
 """Target platforms used for testing purposes."""
 
+load("@bazel_features//:features.bzl", "bazel_features")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("//zig:toolchain.bzl", "zig_target_toolchain")
 load(":defs.bzl", "empty_toolchain")
@@ -126,6 +127,7 @@ empty_toolchain(name = "empty_toolchain")
 
 toolchain(
     name = "unconstrained_default_test_toolchain",
+    target_compatible_with = [] if bazel_features.toolchains.has_default_test_toolchain_type else ["@platforms//:incompatible"],
     toolchain = ":empty_toolchain",
     toolchain_type = "@bazel_tools//tools/test:default_test_toolchain_type",
 )

--- a/zig/tests/platforms/BUILD.bazel
+++ b/zig/tests/platforms/BUILD.bazel
@@ -1,5 +1,6 @@
 """Target platforms used for testing purposes."""
 
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("//zig:toolchain.bzl", "zig_target_toolchain")
 load(":defs.bzl", "empty_toolchain")
 
@@ -127,4 +128,10 @@ toolchain(
     name = "unconstrained_default_test_toolchain",
     toolchain = ":empty_toolchain",
     toolchain_type = "@bazel_tools//tools/test:default_test_toolchain_type",
+)
+
+bzl_library(
+    name = "defs",
+    srcs = ["defs.bzl"],
+    visibility = ["//visibility:public"],
 )

--- a/zig/tests/platforms/defs.bzl
+++ b/zig/tests/platforms/defs.bzl
@@ -1,0 +1,5 @@
+"""Helper rules and functions for platform tests."""
+
+empty_toolchain = rule(
+    implementation = lambda ctx: platform_common.ToolchainInfo(),
+)

--- a/zig/tests/target_platform_test.bzl
+++ b/zig/tests/target_platform_test.bzl
@@ -15,6 +15,8 @@ load(
 _TARGET_PLATFORM = "//command_line_option:platforms"
 _EXTRA_TOOLCHAINS = "//command_line_option:extra_toolchains"
 
+_TOOLCHAIN_UNCONSTRAINED_DEFAULT_TEST = canonical_label("@//zig/tests/platforms:unconstrained_default_test_toolchain")
+
 _TOOLCHAIN_ZIG_ONLY_X86_64_LINUX = canonical_label("@//zig/tests/platforms:zig-only-x86_64-linux_toolchain")
 _PLATFORM_ZIG_ONLY_X86_64_LINUX = canonical_label("@//zig/tests/platforms:zig-only-x86_64-linux")
 
@@ -39,7 +41,10 @@ def _define_target_platform_test(target, option):
 
     return analysistest.make(
         _test_impl,
-        config_settings = {_TARGET_PLATFORM: target},
+        config_settings = {
+            _TARGET_PLATFORM: target,
+            _EXTRA_TOOLCHAINS: _TOOLCHAIN_UNCONSTRAINED_DEFAULT_TEST,
+        },
     )
 
 _target_platform_x86_64_linux_test = _define_target_platform_test(_PLATFORM_X86_64_LINUX, "x86_64-linux-gnu.2.17")
@@ -61,7 +66,10 @@ def _define_build_target_platform_test(mnemonic, target, option):
 
     return analysistest.make(
         _test_impl,
-        config_settings = {_TARGET_PLATFORM: target},
+        config_settings = {
+            _TARGET_PLATFORM: target,
+            _EXTRA_TOOLCHAINS: _TOOLCHAIN_UNCONSTRAINED_DEFAULT_TEST,
+        },
     )
 
 _build_exe_target_platform_x86_64_linux_test = _define_build_target_platform_test("ZigBuildExe", _PLATFORM_X86_64_LINUX, "x86_64-linux-gnu.2.17")
@@ -108,7 +116,10 @@ def _define_file_extension_test(target, extension, basename_pattern = "%s"):
 
     return analysistest.make(
         _test_impl,
-        config_settings = {_TARGET_PLATFORM: target},
+        config_settings = {
+            _TARGET_PLATFORM: target,
+            _EXTRA_TOOLCHAINS: _TOOLCHAIN_UNCONSTRAINED_DEFAULT_TEST,
+        },
     )
 
 _exe_file_extension_x86_64_linux_test = _define_file_extension_test(_PLATFORM_X86_64_LINUX, "")
@@ -138,7 +149,10 @@ def _define_cc_info_test(target, cc_expected):
     return analysistest.make(
         _test_impl,
         config_settings =
-            {_EXTRA_TOOLCHAINS: _TOOLCHAIN_ZIG_ONLY_X86_64_LINUX} |
+            {_EXTRA_TOOLCHAINS: ",".join([
+                _TOOLCHAIN_ZIG_ONLY_X86_64_LINUX,
+                _TOOLCHAIN_UNCONSTRAINED_DEFAULT_TEST,
+            ])} |
             {_TARGET_PLATFORM: target} if target else {},
     )
 


### PR DESCRIPTION
- **chore: update to Bazel 9 pre-release**
- **Remove incompatible_use_toolchain_transition**

- [x] Blocked: https://github.com/bazelbuild/rules_cc/commit/945c95d44e2cf7e84dade38df7987bbb153cb7e7 is not released, yet.
- [x] Blocked: target platform tests fail on test toolchain selection, see https://github.com/bazelbuild/bazel/issues/25823#issuecomment-3241085963.
- [x] Blocked: rules_cc makes use of the new missing `cc_common.escape_label`, see https://github.com/bazelbuild/rules_cc/commit/a1b0a7c1b1628de3da3f6cb3f6f21b428dfd3e3b#r165497333.