### PR TITLE
Refactor ZigModuleInfo to have a single arg rendering path

### DIFF
--- a/zig/private/common/zig_build.bzl
+++ b/zig/private/common/zig_build.bzl
@@ -386,13 +386,12 @@ def zig_build_impl(ctx, *, kind):
 
     zig_module_specifications(
         root_module = root_module,
-        inputs = transitive_inputs,
         args = args,
     )
 
     inputs = depset(
         direct = direct_inputs,
-        transitive = transitive_inputs,
+        transitive = transitive_inputs + [root_module.transitive_inputs],
         order = "preorder",
     )
 

--- a/zig/private/common/zig_docs.bzl
+++ b/zig/private/common/zig_docs.bzl
@@ -120,7 +120,6 @@ def zig_docs_impl(ctx, *, kind):
 
     zig_module_specifications(
         root_module = root_module,
-        inputs = transitive_inputs,
         args = args,
     )
 
@@ -136,7 +135,7 @@ def zig_docs_impl(ctx, *, kind):
 
     inputs = depset(
         direct = direct_inputs,
-        transitive = transitive_inputs,
+        transitive = transitive_inputs + [root_module.transitive_inputs],
         order = "preorder",
     )
 

--- a/zig/private/common/zig_docs.bzl
+++ b/zig/private/common/zig_docs.bzl
@@ -11,7 +11,8 @@ load("//zig/private/common:zig_cache.bzl", "zig_cache_output")
 load("//zig/private/common:zig_lib_dir.bzl", "zig_lib_dir")
 load(
     "//zig/private/providers:zig_module_info.bzl",
-    "zig_module_dependencies",
+    "ZigModuleInfo",
+    "zig_module_info",
     "zig_module_specifications",
 )
 load(
@@ -101,28 +102,26 @@ def zig_docs_impl(ctx, *, kind):
         data = direct_data,
     )
 
-    direct_inputs.append(ctx.file.main)
-    direct_inputs.extend(ctx.files.srcs)
-    direct_inputs.extend(ctx.files.extra_srcs)
     direct_inputs.extend(ctx.files.extra_docs)
 
-    bazel_builtin = bazel_builtin_module(ctx)
+    zdeps = []
+    for dep in ctx.attr.deps:
+        if ZigModuleInfo in dep:
+            zdeps.append(dep[ZigModuleInfo])
 
-    zig_module_dependencies(
-        deps = ctx.attr.deps,
-        extra_deps = [bazel_builtin],
-        args = args,
-        zig_version = zigtoolchaininfo.zig_version,
+    root_module = zig_module_info(
+        name = ctx.attr.name,
+        canonical_name = ctx.label.name,
+        main = ctx.file.main,
+        srcs = ctx.files.srcs,
+        extra_srcs = ctx.files.extra_srcs,
+        deps = zdeps + [bazel_builtin_module(ctx)],
     )
 
-    args.add(ctx.file.main, format = "-M{}=%s".format(ctx.label.name))
-
     zig_module_specifications(
-        deps = ctx.attr.deps,
-        extra_deps = [bazel_builtin],
+        root_module = root_module,
         inputs = transitive_inputs,
         args = args,
-        zig_version = zigtoolchaininfo.zig_version,
     )
 
     zig_settings(

--- a/zig/private/providers/zig_module_info.bzl
+++ b/zig/private/providers/zig_module_info.bzl
@@ -52,7 +52,7 @@ def zig_module_info(*, name, canonical_name, main, srcs = [], extra_srcs = [], d
         canonical_name = canonical_name,
         module_context = module_context,
         transitive_module_contexts = depset(direct = [dep.module_context for dep in deps], transitive = [dep.transitive_module_contexts for dep in deps], order = "postorder"),
-        transitive_inputs = depset(direct = [main] + srcs + extra_srcs, transitive = [dep.transitive_inputs for dep in deps]),
+        transitive_inputs = depset(direct = [main] + srcs + extra_srcs, transitive = [dep.transitive_inputs for dep in deps], order = "preorder"),
     )
 
     return module

--- a/zig/private/providers/zig_module_info.bzl
+++ b/zig/private/providers/zig_module_info.bzl
@@ -67,7 +67,7 @@ def zig_module_specifications(*, root_module, inputs, args):
     """Collect inputs and flags to build Zig modules.
 
     Args:
-        root_module: TODO(corentin)
+        root_module: ZigModuleInfo; The root module for which to render args.
         inputs: List of depset of File; mutable, Append the needed inputs to this list.
         args: Args; mutable, Append the needed Zig compiler flags to this object.
     """

--- a/zig/private/providers/zig_module_info.bzl
+++ b/zig/private/providers/zig_module_info.bzl
@@ -13,16 +13,22 @@ instead the Zig compiler performs whole program compilation.
 FIELDS = {
     "name": "string, The import name of the module.",
     "canonical_name": "string, The canonical name may differ from the import name via remapping.",
-    "main": "File, The main source file of the module.",
-    "deps": "list of ZigModuleInfo, Import dependencies of this module.",
+    "module_context": "struct, per module compilation context required when depending on the module.",
+    "transitive_module_contexts": "depset of struct, All compilation context required by direct and transitive dependencies.",
     "transitive_inputs": "depset of File, All dependencies required when depending on the module, including transitive dependencies.",
-    "transitive_deps": "depset of ZigModuleInfo, All dependencies required when depending on the module, including transitive dependencies.",
 }
 
 ZigModuleInfo = provider(
     fields = FIELDS,
     doc = DOC,
 )
+
+def _zig_module_context(canonical_name, main, deps):
+    return struct(
+        canonical_name = canonical_name,
+        main = main.path,
+        dependency_mappings = tuple([struct(name = dep.name, canonical_name = dep.canonical_name) for dep in deps]),
+    )
 
 def zig_module_info(*, name, canonical_name, main, srcs = [], extra_srcs = [], deps = []):
     """Create `ZigModuleInfo` for a new Zig module.
@@ -38,23 +44,27 @@ def zig_module_info(*, name, canonical_name, main, srcs = [], extra_srcs = [], d
     Returns:
       `ZigModuleInfo`
     """
+
+    module_context = _zig_module_context(canonical_name, main, deps)
+
     module = ZigModuleInfo(
         name = name,
         canonical_name = canonical_name,
-        main = main,
-        deps = tuple(deps),
+        module_context = module_context,
+        transitive_module_contexts = depset(direct = [dep.module_context for dep in deps], transitive = [dep.transitive_module_contexts for dep in deps], order = "postorder"),
         transitive_inputs = depset(direct = [main] + srcs + extra_srcs, transitive = [dep.transitive_inputs for dep in deps]),
-        transitive_deps = depset(direct = deps, transitive = [dep.transitive_deps for dep in deps], order = "postorder"),
     )
 
     return module
 
-def _render_dep(dep):
-    return dep.name + "=" + dep.canonical_name
+def _render_per_module_args(module):
+    args = []
+    for mapping in module.dependency_mappings:
+        args.extend(["--dep", "{}={}".format(mapping.name, mapping.canonical_name)])
 
-def _render_args(*, module, args):
-    args.add_all(module.deps, before_each = "--dep", map_each = _render_dep)
-    args.add(module.main, format = "-M{}=%s".format(module.canonical_name))
+    args.append("-M{name}={src}".format(name = module.canonical_name, src = module.main))
+
+    return args
 
 def zig_module_specifications(*, root_module, args):
     """Collect inputs and flags to build Zig modules.
@@ -63,12 +73,7 @@ def zig_module_specifications(*, root_module, args):
         root_module: ZigModuleInfo; The root module for which to render args.
         args: Args; mutable, Append the needed Zig compiler flags to this object.
     """
-    _render_args(
-        module = root_module,
-        args = args,
-    )
-    for dep in root_module.transitive_deps.to_list():
-        _render_args(
-            module = dep,
-            args = args,
-        )
+
+    # The first module is the main module.
+    args.add_all(_render_per_module_args(root_module.module_context))
+    args.add_all(root_module.transitive_module_contexts, map_each = _render_per_module_args)

--- a/zig/private/providers/zig_module_info.bzl
+++ b/zig/private/providers/zig_module_info.bzl
@@ -13,8 +13,11 @@ instead the Zig compiler performs whole program compilation.
 FIELDS = {
     "name": "string, The import name of the module.",
     "canonical_name": "string, The canonical name may differ from the import name via remapping.",
-    "transitive_args": "depset of struct, All module CLI specifications required when depending on the module, including transitive dependencies, to be rendered.",
-    "transitive_inputs": "depset of File, All build inputs files required when depending on the module, including transitive dependencies.",
+    "main": "File, The main source file of the module.",
+    "srcs": "list of File, Other Zig source files that belong to the module.",
+    "extra_srcs": "list of File, Other files that belong to the module.",
+    "deps": "list of ZigModuleInfo, Import dependencies of this module.",
+    "transitive_deps": "depset of ZigModuleInfo, All dependencies required when depending on the module, including transitive dependencies.",
 }
 
 ZigModuleInfo = provider(
@@ -22,7 +25,7 @@ ZigModuleInfo = provider(
     doc = DOC,
 )
 
-def zig_module_info(*, name, canonical_name, main, srcs, extra_srcs, deps):
+def zig_module_info(*, name, canonical_name, main, srcs = [], extra_srcs = [], deps = []):
     """Create `ZigModuleInfo` for a new Zig module.
 
     Args:
@@ -36,111 +39,46 @@ def zig_module_info(*, name, canonical_name, main, srcs, extra_srcs, deps):
     Returns:
       `ZigModuleInfo`
     """
-    args_transitive = []
-    srcs_transitive = []
-
-    for dep in deps:
-        args_transitive.append(dep.transitive_args)
-        srcs_transitive.append(dep.transitive_inputs)
-
-    arg_direct = _module_args(
-        canonical_name = canonical_name,
-        main = main,
-        deps = deps,
-    )
-    srcs_direct = [main] + srcs + extra_srcs
-
-    transitive_args = depset(direct = [arg_direct], transitive = args_transitive)
-    transitive_inputs = depset(direct = srcs_direct, transitive = srcs_transitive)
     module = ZigModuleInfo(
         name = name,
         canonical_name = canonical_name,
-        transitive_args = transitive_args,
-        transitive_inputs = transitive_inputs,
+        main = main,
+        srcs = tuple(srcs),
+        extra_srcs = tuple(extra_srcs),
+        deps = tuple(deps),
+        transitive_deps = depset(direct = deps, transitive = [dep.transitive_deps for dep in deps], order = "postorder"),
     )
 
     return module
 
-def _dep_arg(dep):
-    if dep.canonical_name != dep.name:
-        return struct(name = dep.name, canonical_name = dep.canonical_name)
-    else:
-        return struct(name = dep.name)
-
-def _module_args(*, canonical_name, main, deps):
-    return struct(
-        name = canonical_name,
-        main = main.path,
-        deps = tuple([_dep_arg(dep) for dep in deps]),
-    )
-
 def _render_dep(dep):
-    dep_spec = dep.name
+    return dep.name + "=" + dep.canonical_name
 
-    if hasattr(dep, "canonical_name") and dep.canonical_name != dep.name:
-        dep_spec += "=" + dep.canonical_name
+def _add_module_files(inputs, module):
+    deps = (module.main,) + module.srcs + module.extra_srcs
+    inputs.append(depset(direct = deps))
 
-    return dep_spec
+def _render_args(*, module, inputs, args):
+    args.add_all(module.deps, before_each = "--dep", map_each = _render_dep)
+    args.add(module.main, format = "-M{}=%s".format(module.canonical_name))
+    _add_module_files(inputs, module)
 
-def _render_args(args):
-    rendered = []
-
-    for dep in args.deps:
-        rendered.extend(["--dep", _render_dep(dep)])
-
-    rendered.extend(["-M{name}={main}".format(
-        name = args.name,
-        main = args.main,
-    )])
-
-    return rendered
-
-def zig_module_dependencies(*, zig_version, deps, extra_deps = [], args):
-    """Collect flags for the Zig main module to depend on other modules.
-
-    Args:
-      zig_version: string, The version of the Zig SDK.
-      deps: List of Target, Considers the targets that have a ZigModuleInfo provider.
-      extra_deps: List of ZigModuleInfo.
-      args: Args; mutable, Append the needed Zig compiler flags to this object.
-    """
-    _ = zig_version  # @unused
-    deps_args = []
-
-    modules = [
-        dep[ZigModuleInfo]
-        for dep in deps
-        if ZigModuleInfo in dep
-    ] + extra_deps
-
-    for module in modules:
-        deps_args.append(_render_dep(module))
-
-    args.add_all(deps_args, before_each = "--dep")
-
-def zig_module_specifications(*, zig_version, deps, extra_deps = [], inputs, args):
+def zig_module_specifications(*, root_module, inputs, args):
     """Collect inputs and flags to build Zig modules.
 
     Args:
-      zig_version: string, The version of the Zig SDK.
-      deps: List of Target, Considers the targets that have a ZigModuleInfo provider.
-      extra_deps: List of ZigModuleInfo.
-      inputs: List of depset of File; mutable, Append the needed inputs to this list.
-      args: Args; mutable, Append the needed Zig compiler flags to this object.
+        root_module: TODO(corentin)
+        inputs: List of depset of File; mutable, Append the needed inputs to this list.
+        args: Args; mutable, Append the needed Zig compiler flags to this object.
     """
-    _ = zig_version  # @unused
-    transitive_args = []
-
-    modules = [
-        dep[ZigModuleInfo]
-        for dep in deps
-        if ZigModuleInfo in dep
-    ] + extra_deps
-
-    for module in modules:
-        transitive_args.append(module.transitive_args)
-        inputs.append(module.transitive_inputs)
-
-    render_args = _render_args
-
-    args.add_all(depset(transitive = transitive_args), map_each = render_args)
+    _render_args(
+        module = root_module,
+        inputs = inputs,
+        args = args,
+    )
+    for dep in root_module.transitive_deps.to_list():
+        _render_args(
+            module = dep,
+            inputs = inputs,
+            args = args,
+        )

--- a/zig/tests/module_info_test.bzl
+++ b/zig/tests/module_info_test.bzl
@@ -1,5 +1,6 @@
 """Unit tests for ZigModuleInfo functions.
 """
+
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
 load(
@@ -33,7 +34,6 @@ def _bazel_builtin_dep(label):
     return "'bazel_builtin={}'".format(_bazel_builtin_name(label))
 
 def _write_simple_module_expected_specs_args_impl(ctx):
-
     mod = ctx.attr.mod[ZigModuleInfo]
 
     expected = []
@@ -59,7 +59,6 @@ _write_simple_module_expected_specs_args = rule(
 )
 
 def _write_module_specs_args_impl(ctx):
-
     args = ctx.actions.args()
 
     zig_module_specifications(
@@ -174,8 +173,6 @@ _write_nested_module_expected_specs_args = rule(
 )
 
 def module_info_test_suite(name):
-
-
     _write_simple_module_expected_specs_args(
         name = "simple_expected",
         mod = "//zig/tests/multiple-sources-module:data",
@@ -197,7 +194,6 @@ def module_info_test_suite(name):
         file2 = "simple_actual.txt",
         size = "small",
     )
-
 
     _write_nested_module_expected_specs_args(
         name = "nested_expected",

--- a/zig/tests/module_info_test.bzl
+++ b/zig/tests/module_info_test.bzl
@@ -172,31 +172,36 @@ _write_nested_module_expected_specs_args = rule(
 )
 
 def module_info_test_suite(name):
+    """Generate module info test suite.
+
+    Args:
+        name: The name of the test suite.
+    """
     _write_simple_module_expected_specs_args(
-        name = "simple_expected",
+        name = name + "_simple_expected",
         mod = "//zig/tests/multiple-sources-module:data",
         mod_main = "//zig/tests/multiple-sources-module:data.zig",
-        out = "simple_expected.txt",
+        out = name + "_simple_expected.txt",
         tags = ["manual"],
     )
 
     _write_module_specs_args(
-        name = "simple_actual",
+        name = name + "_simple_actual",
         mod = "//zig/tests/multiple-sources-module:data",
-        out = "simple_actual.txt",
+        out = name + "_simple_actual.txt",
         tags = ["manual"],
     )
 
     diff_test(
-        name = "simple_diff_test",
+        name = name + "_simple_diff_test",
         failure_message = "generated module specifications do not match",
-        file1 = "simple_expected.txt",
-        file2 = "simple_actual.txt",
+        file1 = name + "_simple_expected.txt",
+        file2 = name + "_simple_actual.txt",
         size = "small",
     )
 
     _write_nested_module_expected_specs_args(
-        name = "nested_expected",
+        name = name + "_nested_expected",
         mods = [
             "//zig/tests/nested-modules:a",
             "//zig/tests/nested-modules:b",
@@ -213,29 +218,29 @@ def module_info_test_suite(name):
             "//zig/tests/nested-modules:e.zig",
             "//zig/tests/nested-modules:f.zig",
         ],
-        out = "nested_expected.txt",
+        out = name + "_nested_expected.txt",
         tags = ["manual"],
     )
 
     _write_module_specs_args(
-        name = "nested_actual",
+        name = name + "_nested_actual",
         mod = "//zig/tests/nested-modules:a",
-        out = "nested_actual.txt",
+        out = name + "_nested_actual.txt",
         tags = ["manual"],
     )
 
     diff_test(
-        name = "nested_diff_test",
+        name = name + "_nested_diff_test",
         failure_message = "generated module specifications do not match",
-        file1 = "nested_expected.txt",
-        file2 = "nested_actual.txt",
+        file1 = name + "_nested_expected.txt",
+        file2 = name + "_nested_actual.txt",
         size = "small",
     )
 
     native.test_suite(
         name = name,
         tests = [
-            "simple_diff_test",
-            "nested_diff_test",
+            name + "_simple_diff_test",
+            name + "_nested_diff_test",
         ],
     )

--- a/zig/tests/module_info_test.bzl
+++ b/zig/tests/module_info_test.bzl
@@ -40,7 +40,7 @@ def _write_simple_module_expected_specs_args_impl(ctx):
     expected.extend(["--dep", _bazel_builtin_dep(ctx.attr.mod.label)])
     expected.extend(["'-M{name}={src}'".format(
         name = mod.name,
-        src = mod.main.path,
+        src = ctx.file.mod_main.path,
     )])
     expected.extend(_bazel_builtin_mod_flags(ctx, ctx.attr.mod.label))
 
@@ -63,7 +63,6 @@ def _write_module_specs_args_impl(ctx):
 
     zig_module_specifications(
         root_module = ctx.attr.mod[ZigModuleInfo],
-        inputs = [],
         args = args,
     )
 
@@ -96,9 +95,9 @@ def _write_nested_module_expected_specs_args_impl(ctx):
             mod_flags = _bazel_builtin_mod_flags(ctx, mod.label),
             dep = _bazel_builtin_dep(mod.label),
             file = [
-                zmod.main
-                for zmod in mods[mod.label.name].transitive_deps.to_list()
-                if zmod.main.path == _bazel_builtin_file_name(ctx, mod.label)
+                file
+                for file in mods[mod.label.name].transitive_inputs.to_list()
+                if file.path == _bazel_builtin_file_name(ctx, mod.label)
             ],
         )
         for mod in ctx.attr.mods
@@ -176,6 +175,7 @@ def module_info_test_suite(name):
     _write_simple_module_expected_specs_args(
         name = "simple_expected",
         mod = "//zig/tests/multiple-sources-module:data",
+        mod_main = "//zig/tests/multiple-sources-module:data.zig",
         out = "simple_expected.txt",
         tags = ["manual"],
     )

--- a/zig/tests/module_info_test.bzl
+++ b/zig/tests/module_info_test.bzl
@@ -1,64 +1,12 @@
 """Unit tests for ZigModuleInfo functions.
 """
-
 load("@bazel_skylib//lib:paths.bzl", "paths")
-load("@bazel_skylib//lib:sets.bzl", "sets")
-load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
 load(
     "//zig/private/providers:zig_module_info.bzl",
     "ZigModuleInfo",
-    "zig_module_dependencies",
     "zig_module_specifications",
 )
-
-def _mock_args():
-    self_args = []
-
-    def add_all(args, *, map_each = None, before_each = None):
-        if type(args) == "depset":
-            args = args.to_list()
-
-        if map_each != None:
-            mapped = []
-
-            for arg in args:
-                result = map_each(arg)
-                if result == None or result == []:
-                    continue
-                if type(result) == "list":
-                    mapped.extend(result)
-                else:
-                    mapped.append(result)
-
-            args = mapped
-
-        if before_each != None:
-            transformed = []
-
-            for arg in args:
-                transformed.extend([before_each, arg])
-
-            args = transformed
-
-        for arg in args:
-            if type(arg) == "File":
-                self_args.append(arg.path)
-            else:
-                self_args.append(arg)
-
-    def add_joined(arg_name, args, *, join_with):
-        if args:
-            self_args.append(arg_name)
-            self_args.append(join_with.join(args))
-
-    def get_args():
-        return self_args
-
-    return struct(
-        add_all = add_all,
-        add_joined = add_joined,
-        get_args = get_args,
-    )
 
 def _bazel_builtin_name(label):
     return "bazel_builtin_A{repo}_S_S{package}_C{target}".format(
@@ -76,90 +24,64 @@ def _bazel_builtin_file_name(ctx, label):
     )
 
 def _bazel_builtin_mod_flags(ctx, label):
-    return ["-M{}={}".format(
+    return ["'-M{}={}'".format(
         _bazel_builtin_name(label),
         _bazel_builtin_file_name(ctx, label),
     )]
 
 def _bazel_builtin_dep(label):
-    return "bazel_builtin={}".format(_bazel_builtin_name(label))
+    return "'bazel_builtin={}'".format(_bazel_builtin_name(label))
 
-def _single_module_test_impl(ctx):
-    env = unittest.begin(ctx)
+def _write_simple_module_expected_specs_args_impl(ctx):
 
-    module = ctx.attr.mod[ZigModuleInfo]
-
-    args = _mock_args()
-
-    zig_module_dependencies(
-        deps = [ctx.attr.mod],
-        args = args,
-        zig_version = "0.15.1",
-    )
+    mod = ctx.attr.mod[ZigModuleInfo]
 
     expected = []
-    expected.extend(["--dep", module.name])
-
-    asserts.equals(
-        env,
-        expected,
-        args.get_args(),
-        "zig_module_dependencies should generate the expected arguments.",
-    )
-
-    transitive_inputs = []
-    args = _mock_args()
-
-    zig_module_specifications(
-        deps = [ctx.attr.mod],
-        inputs = transitive_inputs,
-        args = args,
-        zig_version = "0.15.1",
-    )
-
-    expected = []
-    expected.extend(_bazel_builtin_mod_flags(ctx, ctx.attr.mod.label))
     expected.extend(["--dep", _bazel_builtin_dep(ctx.attr.mod.label)])
-    expected.extend(["-M{name}={src}".format(
-        name = module.name,
-        src = ctx.file.mod_main.path,
+    expected.extend(["'-M{name}={src}'".format(
+        name = mod.name,
+        src = mod.main.path,
     )])
+    expected.extend(_bazel_builtin_mod_flags(ctx, ctx.attr.mod.label))
 
-    asserts.equals(
-        env,
-        expected,
-        args.get_args(),
-        "zig_module_specifications should generate the expected arguments.",
+    ctx.actions.write(
+        output = ctx.outputs.out,
+        content = "\n".join(expected) + "\n",
     )
 
-    bazel_builtin_file = [
-        file
-        for file in module.transitive_inputs.to_list()
-        if file.path == _bazel_builtin_file_name(ctx, ctx.attr.mod.label)
-    ]
-
-    inputs = depset(transitive = transitive_inputs)
-    asserts.set_equals(
-        env,
-        sets.make([ctx.file.mod_main] + ctx.files.mod_srcs + bazel_builtin_file),
-        sets.make(inputs.to_list()),
-        "zig_module_specifications should capture all module files.",
-    )
-
-    return unittest.end(env)
-
-_single_module_test = unittest.make(
-    _single_module_test_impl,
+_write_simple_module_expected_specs_args = rule(
+    _write_simple_module_expected_specs_args_impl,
     attrs = {
         "mod": attr.label(providers = [ZigModuleInfo]),
         "mod_main": attr.label(allow_single_file = True),
-        "mod_srcs": attr.label_list(allow_files = True),
+        "out": attr.output(mandatory = True),
     },
 )
 
-def _nested_modules_test_impl(ctx):
-    env = unittest.begin(ctx)
+def _write_module_specs_args_impl(ctx):
 
+    args = ctx.actions.args()
+
+    zig_module_specifications(
+        root_module = ctx.attr.mod[ZigModuleInfo],
+        inputs = [],
+        args = args,
+    )
+
+    ctx.actions.write(
+        output = ctx.outputs.out,
+        content = args,
+    )
+
+_write_module_specs_args = rule(
+    _write_module_specs_args_impl,
+    attrs = {
+        "mod": attr.label(providers = [ZigModuleInfo]),
+        "out": attr.output(mandatory = True),
+    },
+)
+
+def _write_nested_module_expected_specs_args_impl(ctx):
     mods = {
         mod.label.name: mod[ZigModuleInfo]
         for mod in ctx.attr.mods
@@ -175,154 +97,149 @@ def _nested_modules_test_impl(ctx):
             mod_flags = _bazel_builtin_mod_flags(ctx, mod.label),
             dep = _bazel_builtin_dep(mod.label),
             file = [
-                file
-                for file in mods[mod.label.name].transitive_inputs.to_list()
-                if file.path == _bazel_builtin_file_name(ctx, mod.label)
+                zmod.main
+                for zmod in mods[mod.label.name].transitive_deps.to_list()
+                if zmod.main.path == _bazel_builtin_file_name(ctx, mod.label)
             ],
         )
         for mod in ctx.attr.mods
     }
 
-    args = _mock_args()
-
-    zig_module_dependencies(
-        deps = [dep for dep in ctx.attr.mods if dep.label.name == "a"],
-        args = args,
-        zig_version = "0.15.1",
-    )
-
     expected = []
-    expected.extend(["--dep", "a"])
+    expected.extend([
+        "--dep",
+        "'b=b'",
+        "--dep",
+        "'c=c'",
+        "--dep",
+        "'d=d'",
+        "--dep",
+        bazel_builtins["a"].dep,
+        "'-Ma={}'".format(mod_mains["a"].path),
+    ])
 
-    asserts.equals(
-        env,
-        expected,
-        args.get_args(),
-        "zig_module_dependencies should emit the direct dependencies onto the command-line.",
-    )
-
-    transitive_inputs = []
-    args = _mock_args()
-
-    zig_module_specifications(
-        deps = [dep for dep in ctx.attr.mods if dep.label.name == "a"],
-        inputs = transitive_inputs,
-        args = args,
-        zig_version = "0.15.1",
-    )
-
-    expected = []
     expected.extend(bazel_builtins["e"].mod_flags)
     expected.extend([
         "--dep",
         bazel_builtins["e"].dep,
-        "-Me={}".format(mod_mains["e"].path),
+        "'-Me={}'".format(mod_mains["e"].path),
     ])
     expected.extend(bazel_builtins["b"].mod_flags)
-    expected.extend([
-        "--dep",
-        "e",
-        "--dep",
-        bazel_builtins["b"].dep,
-        "-Mb={}".format(mod_mains["b"].path),
-    ])
     expected.extend(bazel_builtins["c"].mod_flags)
-    expected.extend([
-        "--dep",
-        "e",
-        "--dep",
-        bazel_builtins["c"].dep,
-        "-Mc={}".format(mod_mains["c"].path),
-    ])
     expected.extend(bazel_builtins["f"].mod_flags)
+
     expected.extend([
         "--dep",
-        "e",
+        "'e=e'",
         "--dep",
         bazel_builtins["f"].dep,
-        "-Mf={}".format(mod_mains["f"].path),
+        "'-Mf={}'".format(mod_mains["f"].path),
     ])
     expected.extend(bazel_builtins["d"].mod_flags)
     expected.extend([
         "--dep",
-        "f",
+        "'e=e'",
         "--dep",
-        bazel_builtins["d"].dep,
-        "-Md={}".format(mod_mains["d"].path),
+        bazel_builtins["b"].dep,
+        "'-Mb={}'".format(mod_mains["b"].path),
     ])
-    expected.extend(bazel_builtins["a"].mod_flags)
     expected.extend([
         "--dep",
-        "b",
+        "'e=e'",
         "--dep",
-        "c",
-        "--dep",
-        "d",
-        "--dep",
-        bazel_builtins["a"].dep,
-        "-Ma={}".format(mod_mains["a"].path),
+        bazel_builtins["c"].dep,
+        "'-Mc={}'".format(mod_mains["c"].path),
     ])
+    expected.extend([
+        "--dep",
+        "'f=f'",
+        "--dep",
+        bazel_builtins["d"].dep,
+        "'-Md={}'".format(mod_mains["d"].path),
+    ])
+    expected.extend(bazel_builtins["a"].mod_flags)
 
-    asserts.equals(
-        env,
-        expected,
-        args.get_args(),
-        "zig_module_specifications should unfold the transitive dependency graph onto the command-line.",
+    ctx.actions.write(
+        output = ctx.outputs.out,
+        content = "\n".join(expected) + "\n",
     )
 
-    inputs = depset(transitive = transitive_inputs)
-    asserts.set_equals(
-        env,
-        sets.make([
-            src
-            for mod in mods.values()
-            for src in [mod_mains[mod.name]] + bazel_builtins[mod.name].file
-        ]),
-        sets.make(inputs.to_list()),
-        "zig_module_specifications should capture all module files.",
-    )
-
-    return unittest.end(env)
-
-_nested_modules_test = unittest.make(
-    _nested_modules_test_impl,
+_write_nested_module_expected_specs_args = rule(
+    _write_nested_module_expected_specs_args_impl,
     attrs = {
         "mods": attr.label_list(providers = [ZigModuleInfo]),
         "mod_mains": attr.label_list(allow_files = True),
+        "out": attr.output(mandatory = True),
     },
 )
 
 def module_info_test_suite(name):
-    unittest.suite(
-        name,
-        lambda name: _single_module_test(
-            name = name,
-            mod = "//zig/tests/multiple-sources-module:data",
-            mod_main = "//zig/tests/multiple-sources-module:data.zig",
-            mod_srcs = [
-                "//zig/tests/multiple-sources-module:data/hello.zig",
-                "//zig/tests/multiple-sources-module:data/world.zig",
-            ],
-            size = "small",
-        ),
-        lambda name: _nested_modules_test(
-            name = name,
-            mods = [
-                "//zig/tests/nested-modules:a",
-                "//zig/tests/nested-modules:b",
-                "//zig/tests/nested-modules:c",
-                "//zig/tests/nested-modules:d",
-                "//zig/tests/nested-modules:e",
-                "//zig/tests/nested-modules:f",
-            ],
-            mod_mains = [
-                "//zig/tests/nested-modules:a.zig",
-                "//zig/tests/nested-modules:b.zig",
-                "//zig/tests/nested-modules:c.zig",
-                "//zig/tests/nested-modules:d.zig",
-                "//zig/tests/nested-modules:e.zig",
-                "//zig/tests/nested-modules:f.zig",
-            ],
-            size = "small",
-        ),
+
+
+    _write_simple_module_expected_specs_args(
+        name = "simple_expected",
+        mod = "//zig/tests/multiple-sources-module:data",
+        out = "simple_expected.txt",
+        tags = ["manual"],
+    )
+
+    _write_module_specs_args(
+        name = "simple_actual",
+        mod = "//zig/tests/multiple-sources-module:data",
+        out = "simple_actual.txt",
+        tags = ["manual"],
+    )
+
+    diff_test(
+        name = "simple_diff_test",
+        failure_message = "generated module specifications do not match",
+        file1 = "simple_expected.txt",
+        file2 = "simple_actual.txt",
+        size = "small",
+    )
+
+
+    _write_nested_module_expected_specs_args(
+        name = "nested_expected",
+        mods = [
+            "//zig/tests/nested-modules:a",
+            "//zig/tests/nested-modules:b",
+            "//zig/tests/nested-modules:c",
+            "//zig/tests/nested-modules:d",
+            "//zig/tests/nested-modules:e",
+            "//zig/tests/nested-modules:f",
+        ],
+        mod_mains = [
+            "//zig/tests/nested-modules:a.zig",
+            "//zig/tests/nested-modules:b.zig",
+            "//zig/tests/nested-modules:c.zig",
+            "//zig/tests/nested-modules:d.zig",
+            "//zig/tests/nested-modules:e.zig",
+            "//zig/tests/nested-modules:f.zig",
+        ],
+        out = "nested_expected.txt",
+        tags = ["manual"],
+    )
+
+    _write_module_specs_args(
+        name = "nested_actual",
+        mod = "//zig/tests/nested-modules:a",
+        out = "nested_actual.txt",
+        tags = ["manual"],
+    )
+
+    diff_test(
+        name = "nested_diff_test",
+        failure_message = "generated module specifications do not match",
+        file1 = "nested_expected.txt",
+        file2 = "nested_actual.txt",
+        size = "small",
+    )
+
+    native.test_suite(
+        name = name,
+        tests = [
+            "simple_diff_test",
+            "nested_diff_test",
+        ],
     )


### PR DESCRIPTION
Part of #480 

This PR refactors `ZigModuleInfo` so that --dep and -M cli args are computed transitively from 1 single ZigModuleInfo root.

While doing this, I found that the _mock_args implementation was not compliant with the actual `ctx.actions.args` implementation, especially when using `depset`. 

I took the opportunity to rewrite those tests using custom rules and `diff_test` so that we are sure that what we test is actually what is going to end up in the action run.