### PR TITLE
chore: exclude Zig 0.13.0 in automated update

### DIFF
--- a/util/update_zig_versions.py
+++ b/util/update_zig_versions.py
@@ -10,6 +10,7 @@ _ZIG_INDEX_URL = "https://ziglang.org/download/index.json"
 
 _UNSUPPORTED_VERSIONS = [
     "0.14.0",
+    "0.13.0",
     "0.12.1",
     "0.12.0",
     "0.11.0",


### PR DESCRIPTION
Closes #509

Oversight in #502
