### PR TITLE
feat!: remove zig_library

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -534,28 +534,3 @@ zig_test(
 | <a id="zig_test-zigopts"></a>zigopts |  Additional list of flags passed to the zig compiler. Subject to location expansion.<br><br>This is an advanced feature that can conflict with attributes, build settings, and other flags defined by the toolchain itself. Use this at your own risk of hitting undefined behaviors.   | List of strings | optional |  `[]`  |
 
 
-<a id="zig_library"></a>
-
-## zig_library
-
-<pre>
-load("@rules_zig//zig:defs.bzl", "zig_library")
-
-zig_library(*, <a href="#zig_library-name">name</a>, <a href="#zig_library-kwargs">**kwargs</a>)
-</pre>
-
-Alias for `zig_static_library`.
-
-**PARAMETERS**
-
-
-| Name  | Description | Default Value |
-| :------------- | :------------- | :------------- |
-| <a id="zig_library-name"></a>name |  string, a unique name for the rule.   |  none |
-| <a id="zig_library-kwargs"></a>kwargs |  keyword arguments to forward to `zig_static_library`.   |  none |
-
-**DEPRECATED**
-
-The `zig_library` rule is deprecated, use `zig_static_library` instead.
-
-

--- a/zig/defs.bzl
+++ b/zig/defs.bzl
@@ -27,30 +27,3 @@ zig_test = _zig_test
 zig_configure = _zig_configure
 zig_configure_binary = _zig_configure_binary
 zig_configure_test = _zig_configure_test
-
-def zig_library(*, name, **kwargs):
-    """Alias for `zig_static_library`.
-
-    Args:
-      name: string, a unique name for the rule.
-      **kwargs: keyword arguments to forward to `zig_static_library`.
-
-    Deprecated:
-      The `zig_library` rule is deprecated, use `zig_static_library` instead.
-    """
-    target = native.package_relative_label(name)
-    package = native.package_relative_label("__pkg__")
-
-    # buildifier: disable=print
-    print("""\
-The `zig_library` rule is deprecated, use `zig_static_library` instead.
-You can use the following buildozer commands to fix it.
-buildozer 'fix movePackageToTop' {package}
-buildozer 'set kind zig_static_library' {target}
-buildozer 'new_load @rules_zig//zig:defs.bzl zig_static_library' {package}
-buildozer 'fix unusedLoads' {package}
-""".format(
-        target = target,
-        package = package,
-    ))
-    zig_static_library(name = name, **kwargs)


### PR DESCRIPTION
To be released so that we can rename zig_module to zig_library.
As part of #480 

BREAKING CHANGE: `zig_library` is no longer available, use `zig_static_library` instead. Use rules_zig v0.10.0 to migrate.