### PR TITLE
feat!: rename zig_module to zig_library

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -64,14 +64,14 @@ zig_binary(
 | <a id="zig_binary-zigopts"></a>zigopts |  Additional list of flags passed to the zig compiler. Subject to location expansion.<br><br>This is an advanced feature that can conflict with attributes, build settings, and other flags defined by the toolchain itself. Use this at your own risk of hitting undefined behaviors.   | List of strings | optional |  `[]`  |
 
 
-<a id="zig_c_module"></a>
+<a id="zig_c_library"></a>
 
-## zig_c_module
+## zig_c_library
 
 <pre>
-load("@rules_zig//zig:defs.bzl", "zig_c_module")
+load("@rules_zig//zig:defs.bzl", "zig_c_library")
 
-zig_c_module(<a href="#zig_c_module-name">name</a>, <a href="#zig_c_module-data">data</a>, <a href="#zig_c_module-cdeps">cdeps</a>, <a href="#zig_c_module-import_name">import_name</a>)
+zig_c_library(<a href="#zig_c_library-name">name</a>, <a href="#zig_c_library-data">data</a>, <a href="#zig_c_library-cdeps">cdeps</a>, <a href="#zig_c_library-import_name">import_name</a>)
 </pre>
 
 Defines a Zig C module.
@@ -88,9 +88,9 @@ Zig performs whole program compilation.
 **EXAMPLE**
 
 ```bzl
-load("@rules_zig//zig:defs.bzl", "zig_c_module")
+load("@rules_zig//zig:defs.bzl", "zig_c_library")
 
-zig_c_module(
+zig_c_library(
     name = "my-module",
     cdeps = [
         ":cc-library",
@@ -103,10 +103,10 @@ zig_c_module(
 
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="zig_c_module-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="zig_c_module-data"></a>data |  Files required by the module during runtime.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
-| <a id="zig_c_module-cdeps"></a>cdeps |  C dependencies to translate their headers from.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
-| <a id="zig_c_module-import_name"></a>import_name |  The import name of the module.   | String | optional |  `""`  |
+| <a id="zig_c_library-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="zig_c_library-data"></a>data |  Files required by the module during runtime.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="zig_c_library-cdeps"></a>cdeps |  C dependencies to translate their headers from.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
+| <a id="zig_c_library-import_name"></a>import_name |  The import name of the module.   | String | optional |  `""`  |
 
 
 <a id="zig_configure"></a>
@@ -307,19 +307,19 @@ zig_configure_test(
 | <a id="zig_configure_test-zig_version"></a>zig_version |  The Zig SDK version, must be registered using the `zig` module extension.   | String | optional |  `""`  |
 
 
-<a id="zig_module"></a>
+<a id="zig_library"></a>
 
-## zig_module
+## zig_library
 
 <pre>
-load("@rules_zig//zig:defs.bzl", "zig_module")
+load("@rules_zig//zig:defs.bzl", "zig_library")
 
-zig_module(<a href="#zig_module-name">name</a>, <a href="#zig_module-deps">deps</a>, <a href="#zig_module-srcs">srcs</a>, <a href="#zig_module-data">data</a>, <a href="#zig_module-extra_srcs">extra_srcs</a>, <a href="#zig_module-import_name">import_name</a>, <a href="#zig_module-main">main</a>, <a href="#zig_module-zigopts">zigopts</a>)
+zig_library(<a href="#zig_library-name">name</a>, <a href="#zig_library-deps">deps</a>, <a href="#zig_library-srcs">srcs</a>, <a href="#zig_library-data">data</a>, <a href="#zig_library-extra_srcs">extra_srcs</a>, <a href="#zig_library-import_name">import_name</a>, <a href="#zig_library-main">main</a>, <a href="#zig_library-zigopts">zigopts</a>)
 </pre>
 
-Defines a Zig module.
+Defines a Zig library.
 
-A Zig module is a collection of Zig sources with a main source file
+A Zig library is a collection of Zig sources with a main source file
 that defines the module's entry point.
 
 This rule does not perform compilation by itself.
@@ -329,9 +329,9 @@ Zig performs whole program compilation.
 **EXAMPLE**
 
 ```bzl
-load("@rules_zig//zig:defs.bzl", "zig_module")
+load("@rules_zig//zig:defs.bzl", "zig_library")
 
-zig_module(
+zig_library(
     name = "my-module",
     main = "main.zig",
     srcs = [
@@ -348,14 +348,14 @@ zig_module(
 
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="zig_module-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="zig_module-deps"></a>deps |  Other modules required when building the module.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
-| <a id="zig_module-srcs"></a>srcs |  Other Zig source files required when building the module, e.g. files imported using `@import`.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
-| <a id="zig_module-data"></a>data |  Files required by the module during runtime.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
-| <a id="zig_module-extra_srcs"></a>extra_srcs |  Other files required when building the module, e.g. files embedded using `@embedFile`.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
-| <a id="zig_module-import_name"></a>import_name |  The import name of the module.   | String | optional |  `""`  |
-| <a id="zig_module-main"></a>main |  The main source file.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
-| <a id="zig_module-zigopts"></a>zigopts |  Additional list of flags passed to the zig compiler for this module.<br><br>This is an advanced feature that can conflict with attributes, build settings, and other flags defined by the toolchain itself. Use this at your own risk of hitting undefined behaviors.   | List of strings | optional |  `[]`  |
+| <a id="zig_library-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="zig_library-deps"></a>deps |  Other modules required when building the module.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="zig_library-srcs"></a>srcs |  Other Zig source files required when building the module, e.g. files imported using `@import`.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="zig_library-data"></a>data |  Files required by the module during runtime.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="zig_library-extra_srcs"></a>extra_srcs |  Other files required when building the module, e.g. files embedded using `@embedFile`.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="zig_library-import_name"></a>import_name |  The import name of the module.   | String | optional |  `""`  |
+| <a id="zig_library-main"></a>main |  The main source file.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="zig_library-zigopts"></a>zigopts |  Additional list of flags passed to the zig compiler for this module.<br><br>This is an advanced feature that can conflict with attributes, build settings, and other flags defined by the toolchain itself. Use this at your own risk of hitting undefined behaviors.   | List of strings | optional |  `[]`  |
 
 
 <a id="zig_shared_library"></a>
@@ -532,5 +532,55 @@ zig_test(
 | <a id="zig_test-strip_debug_symbols"></a>strip_debug_symbols |  Whether to pass '-fstrip' to the zig compiler to remove debug symbols.   | Boolean | optional |  `False`  |
 | <a id="zig_test-test_runner"></a>test_runner |  Optional Zig file to specify a custom test runner   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="zig_test-zigopts"></a>zigopts |  Additional list of flags passed to the zig compiler. Subject to location expansion.<br><br>This is an advanced feature that can conflict with attributes, build settings, and other flags defined by the toolchain itself. Use this at your own risk of hitting undefined behaviors.   | List of strings | optional |  `[]`  |
+
+
+<a id="zig_c_module"></a>
+
+## zig_c_module
+
+<pre>
+load("@rules_zig//zig:defs.bzl", "zig_c_module")
+
+zig_c_module(*, <a href="#zig_c_module-name">name</a>, <a href="#zig_c_module-kwargs">**kwargs</a>)
+</pre>
+
+Alias for `zig_c_library`.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="zig_c_module-name"></a>name |  string, a unique name for the rule.   |  none |
+| <a id="zig_c_module-kwargs"></a>kwargs |  keyword arguments to forward to `zig_c_library`.   |  none |
+
+**DEPRECATED**
+
+The `zig_c_module` rule is deprecated, use `zig_c_library` instead.
+
+
+<a id="zig_module"></a>
+
+## zig_module
+
+<pre>
+load("@rules_zig//zig:defs.bzl", "zig_module")
+
+zig_module(*, <a href="#zig_module-name">name</a>, <a href="#zig_module-kwargs">**kwargs</a>)
+</pre>
+
+Alias for `zig_library`.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="zig_module-name"></a>name |  string, a unique name for the rule.   |  none |
+| <a id="zig_module-kwargs"></a>kwargs |  keyword arguments to forward to `zig_library`.   |  none |
+
+**DEPRECATED**
+
+The `zig_module` rule is deprecated, use `zig_library` instead.
 
 

--- a/e2e/workspace/bazel_builtin/BUILD.bazel
+++ b/e2e/workspace/bazel_builtin/BUILD.bazel
@@ -1,6 +1,6 @@
-load("@rules_zig//zig:defs.bzl", "zig_module", "zig_test")
+load("@rules_zig//zig:defs.bzl", "zig_library", "zig_test")
 
-zig_module(
+zig_library(
     name = "module",
     main = "module.zig",
 )

--- a/e2e/workspace/data-dependencies/BUILD.bazel
+++ b/e2e/workspace/data-dependencies/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_zig//zig:defs.bzl", "zig_module", "zig_test")
+load("@rules_zig//zig:defs.bzl", "zig_library", "zig_test")
 
 zig_test(
     name = "direct-data",
@@ -7,7 +7,7 @@ zig_test(
     main = "direct-data.zig",
 )
 
-zig_module(
+zig_library(
     name = "direct-module",
     data = ["data.txt"],
     main = "direct-module.zig",
@@ -20,7 +20,7 @@ zig_test(
     deps = [":direct-module"],
 )
 
-zig_module(
+zig_library(
     name = "indirect-module",
     main = "indirect-module.zig",
     deps = [":direct-module"],

--- a/e2e/workspace/embed-file/BUILD.bazel
+++ b/e2e/workspace/embed-file/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
-load("@rules_zig//zig:defs.bzl", "zig_binary", "zig_module", "zig_static_library", "zig_test")
+load("@rules_zig//zig:defs.bzl", "zig_binary", "zig_library", "zig_static_library", "zig_test")
 
 zig_binary(
     name = "binary",
@@ -21,7 +21,7 @@ zig_test(
     main = "main.zig",
 )
 
-zig_module(
+zig_library(
     name = "module",
     extra_srcs = ["message.txt"],
     main = "module.zig",

--- a/e2e/workspace/import-name-attr/BUILD.bazel
+++ b/e2e/workspace/import-name-attr/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
-load("@rules_zig//zig:defs.bzl", "zig_binary", "zig_module")
+load("@rules_zig//zig:defs.bzl", "zig_binary", "zig_library")
 
-zig_module(
+zig_library(
     name = "data",
     import_name = "import-name-attr/data",
     main = "data.zig",

--- a/e2e/workspace/multiple-sources-and-packages-test/BUILD.bazel
+++ b/e2e/workspace/multiple-sources-and-packages-test/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_zig//zig:defs.bzl", "zig_module", "zig_test")
+load("@rules_zig//zig:defs.bzl", "zig_library", "zig_test")
 
 zig_test(
     name = "test",
@@ -13,7 +13,7 @@ zig_test(
     ],
 )
 
-zig_module(
+zig_library(
     name = "pkg",
     main = "pkg/main.zig",
 )

--- a/e2e/workspace/runfiles-library/dependency/BUILD.bazel
+++ b/e2e/workspace/runfiles-library/dependency/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_zig//zig:defs.bzl", "zig_module", "zig_test")
+load("@rules_zig//zig:defs.bzl", "zig_library", "zig_test")
 
 exports_files(["data.txt"])
 
@@ -11,7 +11,7 @@ zig_test(
     deps = ["@rules_zig//zig/runfiles"],
 )
 
-zig_module(
+zig_library(
     name = "module_with_data",
     data = ["@runfiles_library_transitive_dependency//:data.txt"],
     main = "main.zig",

--- a/e2e/workspace/transitive-zig-modules-binary/hello-world/BUILD.bazel
+++ b/e2e/workspace/transitive-zig-modules-binary/hello-world/BUILD.bazel
@@ -1,6 +1,6 @@
-load("@rules_zig//zig:defs.bzl", "zig_module")
+load("@rules_zig//zig:defs.bzl", "zig_library")
 
-zig_module(
+zig_library(
     name = "hello-world",
     main = "hello_world.zig",
     visibility = ["//transitive-zig-modules-binary:__pkg__"],

--- a/e2e/workspace/transitive-zig-modules-binary/hello-world/data/BUILD.bazel
+++ b/e2e/workspace/transitive-zig-modules-binary/hello-world/data/BUILD.bazel
@@ -1,6 +1,6 @@
-load("@rules_zig//zig:defs.bzl", "zig_module")
+load("@rules_zig//zig:defs.bzl", "zig_library")
 
-zig_module(
+zig_library(
     name = "data",
     main = "data.zig",
     visibility = ["//transitive-zig-modules-binary/hello-world:__pkg__"],

--- a/e2e/workspace/transitive-zig-modules-binary/hello-world/data/hello/BUILD.bazel
+++ b/e2e/workspace/transitive-zig-modules-binary/hello-world/data/hello/BUILD.bazel
@@ -1,6 +1,6 @@
-load("@rules_zig//zig:defs.bzl", "zig_module")
+load("@rules_zig//zig:defs.bzl", "zig_library")
 
-zig_module(
+zig_library(
     name = "hello",
     main = "hello.zig",
     visibility = ["//transitive-zig-modules-binary/hello-world/data:__pkg__"],

--- a/e2e/workspace/transitive-zig-modules-binary/hello-world/data/world/BUILD.bazel
+++ b/e2e/workspace/transitive-zig-modules-binary/hello-world/data/world/BUILD.bazel
@@ -1,6 +1,6 @@
-load("@rules_zig//zig:defs.bzl", "zig_module")
+load("@rules_zig//zig:defs.bzl", "zig_library")
 
-zig_module(
+zig_library(
     name = "world",
     main = "world.zig",
     visibility = ["//transitive-zig-modules-binary/hello-world/data:__pkg__"],

--- a/e2e/workspace/transitive-zig-modules-binary/hello-world/io/BUILD.bazel
+++ b/e2e/workspace/transitive-zig-modules-binary/hello-world/io/BUILD.bazel
@@ -1,6 +1,6 @@
-load("@rules_zig//zig:defs.bzl", "zig_module")
+load("@rules_zig//zig:defs.bzl", "zig_library")
 
-zig_module(
+zig_library(
     name = "io",
     main = "io.zig",
     visibility = ["//transitive-zig-modules-binary/hello-world:__pkg__"],

--- a/e2e/workspace/translate-c/transitive-cc-library-zig-binary/BUILD.bazel
+++ b/e2e/workspace/translate-c/transitive-cc-library-zig-binary/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
 load("@rules_cc//cc:defs.bzl", "cc_library")
-load("@rules_zig//zig:defs.bzl", "zig_binary", "zig_c_module", "zig_module")
+load("@rules_zig//zig:defs.bzl", "zig_binary", "zig_c_library", "zig_library")
 
 cc_library(
     name = "local_c",
@@ -8,12 +8,12 @@ cc_library(
     hdrs = ["local.h"],
 )
 
-zig_c_module(
+zig_c_library(
     name = "local_zig",
     cdeps = [":local_c"],
 )
 
-zig_module(
+zig_library(
     name = "module",
     main = "module.zig",
     deps = [":local_zig"],

--- a/e2e/workspace/zig-docs/BUILD.bazel
+++ b/e2e/workspace/zig-docs/BUILD.bazel
@@ -5,14 +5,14 @@ load(
     "@rules_zig//zig:defs.bzl",
     "zig_binary",
     "zig_configure_test",
-    "zig_module",
+    "zig_library",
     "zig_shared_library",
     "zig_static_library",
     "zig_test",
 )
 load("@rules_zig//zig/private:versions.bzl", "TOOL_VERSIONS")
 
-zig_module(
+zig_library(
     name = "hello_world",
     main = "hello_world.zig",
 )

--- a/e2e/workspace/zig-module-binary/data/BUILD.bazel
+++ b/e2e/workspace/zig-module-binary/data/BUILD.bazel
@@ -1,6 +1,6 @@
-load("@rules_zig//zig:defs.bzl", "zig_module")
+load("@rules_zig//zig:defs.bzl", "zig_library")
 
-zig_module(
+zig_library(
     name = "data",
     srcs = [
         "data/hello.zig",

--- a/e2e/workspace/zig-module-binary/io/BUILD.bazel
+++ b/e2e/workspace/zig-module-binary/io/BUILD.bazel
@@ -1,6 +1,6 @@
-load("@rules_zig//zig:defs.bzl", "zig_module")
+load("@rules_zig//zig:defs.bzl", "zig_library")
 
-zig_module(
+zig_library(
     name = "io",
     main = "io.zig",
     visibility = ["//zig-module-binary:__pkg__"],

--- a/zig/BUILD.bazel
+++ b/zig/BUILD.bazel
@@ -41,9 +41,9 @@ bzl_library(
     visibility = ["//visibility:public"],
     deps = [
         "//zig/private:zig_binary",
-        "//zig/private:zig_c_module",
+        "//zig/private:zig_c_library",
         "//zig/private:zig_configure",
-        "//zig/private:zig_module",
+        "//zig/private:zig_library",
         "//zig/private:zig_shared_library",
         "//zig/private:zig_static_library",
         "//zig/private:zig_test",

--- a/zig/defs.bzl
+++ b/zig/defs.bzl
@@ -6,14 +6,14 @@ the current target name or current repository name.
 """
 
 load("//zig/private:zig_binary.bzl", _zig_binary = "zig_binary")
-load("//zig/private:zig_c_module.bzl", _zig_c_module = "zig_c_module")
+load("//zig/private:zig_c_library.bzl", _zig_c_library = "zig_c_library")
 load(
     "//zig/private:zig_configure.bzl",
     _zig_configure = "zig_configure",
     _zig_configure_binary = "zig_configure_binary",
     _zig_configure_test = "zig_configure_test",
 )
-load("//zig/private:zig_module.bzl", _zig_module = "zig_module")
+load("//zig/private:zig_library.bzl", _zig_library = "zig_library")
 load("//zig/private:zig_shared_library.bzl", _zig_shared_library = "zig_shared_library")
 load("//zig/private:zig_static_library.bzl", _zig_static_library = "zig_static_library")
 load("//zig/private:zig_test.bzl", _zig_test = "zig_test")
@@ -21,9 +21,63 @@ load("//zig/private:zig_test.bzl", _zig_test = "zig_test")
 zig_binary = _zig_binary
 zig_static_library = _zig_static_library
 zig_shared_library = _zig_shared_library
-zig_module = _zig_module
-zig_c_module = _zig_c_module
+zig_library = _zig_library
+zig_c_library = _zig_c_library
 zig_test = _zig_test
 zig_configure = _zig_configure
 zig_configure_binary = _zig_configure_binary
 zig_configure_test = _zig_configure_test
+
+def zig_module(*, name, **kwargs):
+    """Alias for `zig_library`.
+
+    Args:
+      name: string, a unique name for the rule.
+      **kwargs: keyword arguments to forward to `zig_library`.
+
+    Deprecated:
+      The `zig_module` rule is deprecated, use `zig_library` instead.
+    """
+    target = native.package_relative_label(name)
+    package = native.package_relative_label("__pkg__")
+
+    # buildifier: disable=print
+    print("""\
+The `zig_module` rule is deprecated, use `zig_library` instead.
+You can use the following buildozer commands to fix it.
+buildozer 'fix movePackageToTop' {package}
+buildozer 'set kind zig_library' {target}
+buildozer 'new_load @rules_zig//zig:defs.bzl zig_library' {package}
+buildozer 'fix unusedLoads' {package}
+""".format(
+        target = target,
+        package = package,
+    ))
+    zig_library(name = name, **kwargs)
+
+def zig_c_module(*, name, **kwargs):
+    """Alias for `zig_c_library`.
+
+    Args:
+      name: string, a unique name for the rule.
+      **kwargs: keyword arguments to forward to `zig_c_library`.
+
+    Deprecated:
+      The `zig_c_module` rule is deprecated, use `zig_c_library` instead.
+    """
+    target = native.package_relative_label(name)
+    package = native.package_relative_label("__pkg__")
+
+    # buildifier: disable=print
+    print("""\
+The `zig_c_module` rule is deprecated, use `zig_c_library` instead.
+You can use the following buildozer commands to fix it.
+buildozer 'fix movePackageToTop' {package}
+buildozer 'set kind zig_c_library' {target}
+buildozer 'new_load @rules_zig//zig:defs.bzl zig_c_library' {package}
+buildozer 'fix unusedLoads' {package}
+""".format(
+        target = target,
+        package = package,
+    ))
+    zig_c_library(name = name, **kwargs)

--- a/zig/private/BUILD.bazel
+++ b/zig/private/BUILD.bazel
@@ -10,8 +10,8 @@ exports_files(
 )
 
 bzl_library(
-    name = "zig_module",
-    srcs = ["zig_module.bzl"],
+    name = "zig_library",
+    srcs = ["zig_library.bzl"],
     visibility = ["//zig:__subpackages__"],
     deps = [
         "//zig/private/common:bazel_builtin",
@@ -22,8 +22,8 @@ bzl_library(
 )
 
 bzl_library(
-    name = "zig_c_module",
-    srcs = ["zig_c_module.bzl"],
+    name = "zig_c_library",
+    srcs = ["zig_c_library.bzl"],
     visibility = ["//zig:__subpackages__"],
     deps = [
         "//zig/private/common:bazel_builtin",
@@ -177,9 +177,9 @@ filegroup(
         ":versions.bzl.tpl",
         ":versions.json",
         ":zig_binary.bzl",
-        ":zig_c_module.bzl",
+        ":zig_c_library.bzl",
         ":zig_configure.bzl",
-        ":zig_module.bzl",
+        ":zig_library.bzl",
         ":zig_shared_library.bzl",
         ":zig_static_library.bzl",
         ":zig_target_toolchain.bzl",

--- a/zig/private/providers/zig_module_info.bzl
+++ b/zig/private/providers/zig_module_info.bzl
@@ -1,4 +1,4 @@
-"""Defines providers for the zig_module rule."""
+"""Defines providers for the zig_library rule."""
 
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("//zig/private:cc_helper.bzl", "need_translate_c")

--- a/zig/private/zig_c_library.bzl
+++ b/zig/private/zig_c_library.bzl
@@ -1,4 +1,4 @@
-"""Implementation of the zig_module rule."""
+"""Implementation of the zig_library rule."""
 
 load("@rules_cc//cc:find_cc_toolchain.bzl", "use_cc_toolchain")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
@@ -26,9 +26,9 @@ Zig performs whole program compilation.
 **EXAMPLE**
 
 ```bzl
-load("@rules_zig//zig:defs.bzl", "zig_c_module")
+load("@rules_zig//zig:defs.bzl", "zig_c_library")
 
-zig_c_module(
+zig_c_library(
     name = "my-module",
     cdeps = [
         ":cc-library",
@@ -60,7 +60,7 @@ TOOLCHAINS = [
 
 FRAGMENTS = ["cpp"]
 
-def _zig_c_module_impl(ctx):
+def _zig_c_library_impl(ctx):
     zigtoolchaininfo = ctx.toolchains["//zig:toolchain_type"].zigtoolchaininfo
 
     transitive_data = []
@@ -106,8 +106,8 @@ def _zig_c_module_impl(ctx):
 
     return [default, module]
 
-zig_c_module = rule(
-    _zig_c_module_impl,
+zig_c_library = rule(
+    _zig_c_library_impl,
     attrs = ATTRS,
     doc = DOC,
     toolchains = TOOLCHAINS,

--- a/zig/private/zig_library.bzl
+++ b/zig/private/zig_library.bzl
@@ -1,4 +1,4 @@
-"""Implementation of the zig_module rule."""
+"""Implementation of the zig_library rule."""
 
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load(
@@ -15,9 +15,9 @@ load(
 )
 
 DOC = """\
-Defines a Zig module.
+Defines a Zig library.
 
-A Zig module is a collection of Zig sources with a main source file
+A Zig library is a collection of Zig sources with a main source file
 that defines the module's entry point.
 
 This rule does not perform compilation by itself.
@@ -27,9 +27,9 @@ Zig performs whole program compilation.
 **EXAMPLE**
 
 ```bzl
-load("@rules_zig//zig:defs.bzl", "zig_module")
+load("@rules_zig//zig:defs.bzl", "zig_library")
 
-zig_module(
+zig_library(
     name = "my-module",
     main = "main.zig",
     srcs = [
@@ -82,7 +82,7 @@ Use this at your own risk of hitting undefined behaviors.
     ),
 } | BAZEL_BUILTIN_ATTRS
 
-def _zig_module_impl(ctx):
+def _zig_library_impl(ctx):
     transitive_data = []
     transitive_runfiles = []
 
@@ -123,8 +123,8 @@ def _zig_module_impl(ctx):
 
     return [default, module]
 
-zig_module = rule(
-    _zig_module_impl,
+zig_library = rule(
+    _zig_library_impl,
     attrs = ATTRS,
     doc = DOC,
     toolchains = ["//zig:toolchain_type"],

--- a/zig/runfiles/BUILD.bazel
+++ b/zig/runfiles/BUILD.bazel
@@ -1,6 +1,6 @@
 load(
     "@rules_zig//zig:defs.bzl",
-    "zig_module",
+    "zig_library",
     "zig_static_library",
     "zig_test",
 )
@@ -14,7 +14,7 @@ _SRCS = [
     "src/Runfiles.zig",
 ]
 
-zig_module(
+zig_library(
     name = "runfiles",
     srcs = _SRCS,
     main = "runfiles.zig",

--- a/zig/tests/import-name-module/BUILD.bazel
+++ b/zig/tests/import-name-module/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_zig//zig:defs.bzl", "zig_module")
+load("@rules_zig//zig:defs.bzl", "zig_library")
 
 exports_files(
     [
@@ -8,14 +8,14 @@ exports_files(
     visibility = ["//zig/tests:__pkg__"],
 )
 
-zig_module(
+zig_library(
     name = "data",
     import_name = "import-name-module/data",
     main = "data.zig",
     visibility = ["//zig/tests:__pkg__"],
 )
 
-zig_module(
+zig_library(
     name = "main",
     main = "main.zig",
     visibility = ["//zig/tests:__pkg__"],

--- a/zig/tests/integration_tests/BUILD.bazel
+++ b/zig/tests/integration_tests/BUILD.bazel
@@ -8,7 +8,7 @@ load(
     "bazel_integration_tests",
     "integration_test_utils",
 )
-load("//zig:defs.bzl", "zig_module", "zig_test")
+load("//zig:defs.bzl", "zig_library", "zig_test")
 load("//zig/private:versions.bzl", "TOOL_VERSIONS")
 
 # gazelle:exclude workspace
@@ -31,7 +31,7 @@ workspace_files = integration_test_utils.glob_workspace_files("workspace") + [
     ".bazelrc.meta",
 ]
 
-zig_module(
+zig_library(
     name = "integration_testing",
     main = "integration_testing.zig",
 )

--- a/zig/tests/module-binary/BUILD.bazel
+++ b/zig/tests/module-binary/BUILD.bazel
@@ -1,11 +1,11 @@
-load("@rules_zig//zig:defs.bzl", "zig_binary", "zig_module")
+load("@rules_zig//zig:defs.bzl", "zig_binary", "zig_library")
 
 exports_files(
     ["main.zig"],
     visibility = ["//zig/tests:__pkg__"],
 )
 
-zig_module(
+zig_library(
     name = "data",
     main = "data.zig",
     visibility = ["//zig/tests:__pkg__"],

--- a/zig/tests/multiple-sources-module/BUILD.bazel
+++ b/zig/tests/multiple-sources-module/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_zig//zig:defs.bzl", "zig_module")
+load("@rules_zig//zig:defs.bzl", "zig_library")
 
 exports_files(
     [
@@ -9,7 +9,7 @@ exports_files(
     visibility = ["//zig/tests:__pkg__"],
 )
 
-zig_module(
+zig_library(
     name = "data",
     srcs = [
         "data/hello.zig",

--- a/zig/tests/nested-modules/BUILD.bazel
+++ b/zig/tests/nested-modules/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_zig//zig:defs.bzl", "zig_module")
+load("@rules_zig//zig:defs.bzl", "zig_library")
 
 exports_files(
     [
@@ -12,7 +12,7 @@ exports_files(
     visibility = ["//zig/tests:__pkg__"],
 )
 
-zig_module(
+zig_library(
     name = "a",
     main = "a.zig",
     visibility = ["//zig/tests:__pkg__"],
@@ -23,34 +23,34 @@ zig_module(
     ],
 )
 
-zig_module(
+zig_library(
     name = "b",
     main = "b.zig",
     visibility = ["//zig/tests:__pkg__"],
     deps = [":e"],
 )
 
-zig_module(
+zig_library(
     name = "c",
     main = "c.zig",
     visibility = ["//zig/tests:__pkg__"],
     deps = [":e"],
 )
 
-zig_module(
+zig_library(
     name = "d",
     main = "d.zig",
     visibility = ["//zig/tests:__pkg__"],
     deps = [":f"],
 )
 
-zig_module(
+zig_library(
     name = "e",
     main = "e.zig",
     visibility = ["//zig/tests:__pkg__"],
 )
 
-zig_module(
+zig_library(
     name = "f",
     main = "f.zig",
     visibility = ["//zig/tests:__pkg__"],

--- a/zig/tests/transitive-modules-zigopts/BUILD.bazel
+++ b/zig/tests/transitive-modules-zigopts/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_zig//zig:defs.bzl", "zig_module")
+load("@rules_zig//zig:defs.bzl", "zig_library")
 
 exports_files(
     [
@@ -8,14 +8,14 @@ exports_files(
     visibility = ["//zig/tests:__pkg__"],
 )
 
-zig_module(
+zig_library(
     name = "a",
     main = "a.zig",
     visibility = ["//zig/tests:__pkg__"],
     zigopts = ["-DFOR_MODULE_A"],
 )
 
-zig_module(
+zig_library(
     name = "b",
     main = "b.zig",
     visibility = ["//zig/tests:__pkg__"],

--- a/zig/tests/translate-c-modules/BUILD.bazel
+++ b/zig/tests/translate-c-modules/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
-load("@rules_zig//zig:defs.bzl", "zig_c_module", "zig_module")
+load("@rules_zig//zig:defs.bzl", "zig_c_library", "zig_library")
 
 exports_files(
     [
@@ -17,13 +17,13 @@ cc_library(
     hdrs = ["data.h"],
 )
 
-zig_c_module(
+zig_c_library(
     name = "data_c_zig",
     cdeps = ["data_c"],
     visibility = ["//zig/tests:__pkg__"],
 )
 
-zig_module(
+zig_library(
     name = "data",
     srcs = [
         "data/hello.zig",
@@ -34,7 +34,7 @@ zig_module(
     deps = [":data_c_zig"],
 )
 
-zig_module(
+zig_library(
     name = "data_global_c",
     srcs = [
         "data/hello.zig",


### PR DESCRIPTION
Follow up PR to #534 

Closes #533

I left zig_module and zig_c_module as alias with deprecation warning.