### PR TITLE
fix: make remote-exec incompatible targets local only

### DIFF
--- a/e2e/workspace/configure-use_cc_common_link/shared-library/BUILD.bazel
+++ b/e2e/workspace/configure-use_cc_common_link/shared-library/BUILD.bazel
@@ -32,6 +32,8 @@ zig_binary(
 zig_configure_binary(
     name = "binary_linked_with_cc_common_link",
     actual = ":binary",
+    # Exclude from RE because of https://github.com/bazelbuild/bazel/issues/26551
+    tags = ["local"],
     use_cc_common_link = True,
 )
 
@@ -48,6 +50,8 @@ zig_static_library(
 zig_configure(
     name = "static_library_linked_with_cc_common_link",
     actual = ":static-library",
+    # Exclude from RE because of https://github.com/bazelbuild/bazel/issues/26551
+    tags = ["local"],
     use_cc_common_link = True,
 )
 
@@ -64,6 +68,8 @@ zig_shared_library(
 zig_configure(
     name = "shared_library_linked_with_cc_common_link",
     actual = ":static-library",
+    # Exclude from RE because of https://github.com/bazelbuild/bazel/issues/26551
+    tags = ["local"],
     use_cc_common_link = True,
 )
 
@@ -82,6 +88,8 @@ zig_configure_test(
     name = "test_linked_with_cc_common_link",
     size = "small",
     actual = ":test",
+    # Exclude from RE because of https://github.com/bazelbuild/bazel/issues/26551
+    tags = ["local"],
     use_cc_common_link = True,
 )
 


### PR DESCRIPTION
Fixes #539 

See https://github.com/bazelbuild/bazel/issues/26551

We symlink the transitioned output in `zig_configure_*` but it gets sent as a regular file on the remote executor which makes the RPATH discovery fail on the remote-executor.

It works locally because there it remains a symlink.