### PR TITLE
fix: avoid Zig 0.15.1 malformed archive issues

### DIFF
--- a/e2e/workspace/configure-threaded/BUILD.bazel
+++ b/e2e/workspace/configure-threaded/BUILD.bazel
@@ -34,6 +34,12 @@ genrule(
     srcs = [":library_single"],
     outs = ["library_single_symbol.txt"],
     cmd = "$(NM) --defined-only $(SRCS) | grep single_threaded > $(OUTS)",
+    target_compatible_with = select({
+        # Zig 0.15.1 sometimes creates malformed archives
+        # https://github.com/ziglang/zig/issues/25069
+        "@zig_toolchains//:0.15.1": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
     toolchains = ["@bazel_tools//tools/cpp:current_cc_toolchain"],
 )
 
@@ -42,6 +48,12 @@ genrule(
     srcs = [":library_multi"],
     outs = ["library_multi_symbol.txt"],
     cmd = "$(NM) --defined-only $(SRCS) | grep multi_threaded > $(OUTS)",
+    target_compatible_with = select({
+        # Zig 0.15.1 sometimes creates malformed archives
+        # https://github.com/ziglang/zig/issues/25069
+        "@zig_toolchains//:0.15.1": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
     toolchains = ["@bazel_tools//tools/cpp:current_cc_toolchain"],
 )
 

--- a/e2e/workspace/configure-use_cc_common_link/shared-library/BUILD.bazel
+++ b/e2e/workspace/configure-use_cc_common_link/shared-library/BUILD.bazel
@@ -32,6 +32,12 @@ zig_binary(
 zig_configure_binary(
     name = "binary_linked_with_cc_common_link",
     actual = ":binary",
+    target_compatible_with = select({
+        # Zig 0.15.1 sometimes creates malformed archives
+        # https://github.com/ziglang/zig/issues/25069
+        "@zig_toolchains//:0.15.1": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
     use_cc_common_link = True,
 )
 
@@ -48,6 +54,12 @@ zig_static_library(
 zig_configure(
     name = "static_library_linked_with_cc_common_link",
     actual = ":static-library",
+    target_compatible_with = select({
+        # Zig 0.15.1 sometimes creates malformed archives
+        # https://github.com/ziglang/zig/issues/25069
+        "@zig_toolchains//:0.15.1": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
     use_cc_common_link = True,
 )
 
@@ -64,6 +76,12 @@ zig_shared_library(
 zig_configure(
     name = "shared_library_linked_with_cc_common_link",
     actual = ":static-library",
+    target_compatible_with = select({
+        # Zig 0.15.1 sometimes creates malformed archives
+        # https://github.com/ziglang/zig/issues/25069
+        "@zig_toolchains//:0.15.1": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
     use_cc_common_link = True,
 )
 
@@ -82,6 +100,12 @@ zig_configure_test(
     name = "test_linked_with_cc_common_link",
     size = "small",
     actual = ":test",
+    target_compatible_with = select({
+        # Zig 0.15.1 sometimes creates malformed archives
+        # https://github.com/ziglang/zig/issues/25069
+        "@zig_toolchains//:0.15.1": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
     use_cc_common_link = True,
 )
 

--- a/e2e/workspace/configure-use_cc_common_link/static-library/BUILD.bazel
+++ b/e2e/workspace/configure-use_cc_common_link/static-library/BUILD.bazel
@@ -19,6 +19,12 @@ zig_binary(
 zig_configure_binary(
     name = "binary_linked_with_cc_common_link",
     actual = ":binary",
+    target_compatible_with = select({
+        # Zig 0.15.1 sometimes creates malformed archives
+        # https://github.com/ziglang/zig/issues/25069
+        "@zig_toolchains//:0.15.1": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
     use_cc_common_link = True,
 )
 
@@ -32,6 +38,12 @@ zig_static_library(
 zig_configure(
     name = "static_library_linked_with_cc_common_link",
     actual = ":static-library",
+    target_compatible_with = select({
+        # Zig 0.15.1 sometimes creates malformed archives
+        # https://github.com/ziglang/zig/issues/25069
+        "@zig_toolchains//:0.15.1": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
     use_cc_common_link = True,
 )
 
@@ -45,6 +57,12 @@ zig_shared_library(
 zig_configure(
     name = "shared_library_linked_with_cc_common_link",
     actual = ":shared-library",
+    target_compatible_with = select({
+        # Zig 0.15.1 sometimes creates malformed archives
+        # https://github.com/ziglang/zig/issues/25069
+        "@zig_toolchains//:0.15.1": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
     use_cc_common_link = True,
 )
 
@@ -60,6 +78,12 @@ zig_configure_test(
     name = "test_linked_with_cc_common_link",
     size = "small",
     actual = ":test",
+    target_compatible_with = select({
+        # Zig 0.15.1 sometimes creates malformed archives
+        # https://github.com/ziglang/zig/issues/25069
+        "@zig_toolchains//:0.15.1": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
     use_cc_common_link = True,
 )
 

--- a/e2e/workspace/link-dependencies/static-library/BUILD.bazel
+++ b/e2e/workspace/link-dependencies/static-library/BUILD.bazel
@@ -18,6 +18,12 @@ zig_binary(
 zig_static_library(
     name = "library",
     main = "main.zig",
+    target_compatible_with = select({
+        # Zig 0.15.1 sometimes creates malformed archives
+        # https://github.com/ziglang/zig/issues/25069
+        "@zig_toolchains//:0.15.1": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
     deps = [":add"],
 )
 

--- a/e2e/workspace/linkopts-attr/BUILD.bazel
+++ b/e2e/workspace/linkopts-attr/BUILD.bazel
@@ -26,6 +26,12 @@ zig_configure_binary(
     name = "binary-use_cc_common_link",
     actual = ":binary",
     tags = ["manual"],
+    target_compatible_with = select({
+        # Zig 0.15.1 sometimes creates malformed archives
+        # https://github.com/ziglang/zig/issues/25069
+        "@zig_toolchains//:0.15.1": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
     use_cc_common_link = True,
 )
 
@@ -33,6 +39,12 @@ zig_configure(
     name = "shared-library-use_cc_common_link",
     actual = ":shared-library",
     tags = ["manual"],
+    target_compatible_with = select({
+        # Zig 0.15.1 sometimes creates malformed archives
+        # https://github.com/ziglang/zig/issues/25069
+        "@zig_toolchains//:0.15.1": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
     use_cc_common_link = True,
 )
 
@@ -40,6 +52,12 @@ zig_configure_test(
     name = "test-use_cc_common_link",
     size = "small",
     actual = ":test",
+    target_compatible_with = select({
+        # Zig 0.15.1 sometimes creates malformed archives
+        # https://github.com/ziglang/zig/issues/25069
+        "@zig_toolchains//:0.15.1": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
     use_cc_common_link = True,
 )
 


### PR DESCRIPTION
Skip library symbol tests with Zig 0.15.1, corresponding CI failure:
https://buildkite.com/bazel/bcr-presubmit/builds/20259/steps/canvas?jid=0199874b-b8d2-4441-914e-634cf422908e#0199874b-b8d2-4441-914e-634cf422908e/447-492

Skip linkopts attribute tests with Zig 0.15.1, corresponding CI failure:
https://buildkite.com/bazel/bcr-presubmit/builds/20276/steps/canvas?jid=01998ace-1c3b-4c4e-9fb1-1293a5a2c19f#01998ace-1c3b-4c4e-9fb1-1293a5a2c19f/444-491

Skip configure use_cc_common_link check, corresponding CI failure
https://buildkite.com/bazel/bcr-presubmit/builds/20277/steps/canvas?jid=01998ae0-bde8-4e77-8089-4bfb1cf5785a#01998ae0-bde8-4e77-8089-4bfb1cf5785a/447-497
