### PR TITLE
feat: expose ZigModuleInfo provider for binaries

### DIFF
--- a/zig/private/common/zig_build.bzl
+++ b/zig/private/common/zig_build.bzl
@@ -369,6 +369,8 @@ buildozer 'move cdeps deps *' {target}
             zigopts = zigopts,
         )
 
+    providers.append(root_module)
+
     zig_settings(
         settings = ctx.attr._settings[ZigSettingsInfo],
         args = global_args,


### PR DESCRIPTION
This is required for ZLS completion to access the dependency graph of binary targets and offer completion for those binary targets.