### PR TITLE
fix: add Zig 0.15.1 to update exclusions

### DIFF
--- a/util/update_zig_versions.py
+++ b/util/update_zig_versions.py
@@ -9,6 +9,7 @@ import urllib.request
 _ZIG_INDEX_URL = "https://ziglang.org/download/index.json"
 
 _UNSUPPORTED_VERSIONS = [
+    "0.15.1",
     "0.14.0",
     "0.13.0",
     "0.12.1",


### PR DESCRIPTION
Forgotten in #569.
Closes #572.
