### PR TITLE
fix: force canonical name for builtin std module name

### DIFF
--- a/zig/private/zig_library.bzl
+++ b/zig/private/zig_library.bzl
@@ -111,12 +111,13 @@ def _zig_library_impl(ctx):
         elif CcInfo in dep:
             cdeps.append(dep[CcInfo])
 
+    import_name = ctx.attr.import_name or ctx.label.name
     module = zig_module_info(
-        name = ctx.attr.import_name or ctx.label.name,
+        name = import_name,
         # Zig doesn't allow having a different module name and import name for std
         # This is to ensure that all modules depend on the same std.
         # It is only helpful when compiling Zig itself with rules_zig
-        canonical_name = "std" if ctx.label.name == "std" else escape_label(label = ctx.label),
+        canonical_name = "std" if import_name == "std" else escape_label(label = ctx.label),
         main = ctx.file.main,
         srcs = ctx.files.srcs,
         extra_srcs = ctx.files.extra_srcs,

--- a/zig/private/zig_library.bzl
+++ b/zig/private/zig_library.bzl
@@ -113,7 +113,10 @@ def _zig_library_impl(ctx):
 
     module = zig_module_info(
         name = ctx.attr.import_name or ctx.label.name,
-        canonical_name = escape_label(label = ctx.label),
+        # Zig doesn't allow having a different module name and import name for std
+        # This is to ensure that all modules depend on the same std.
+        # It is only helpful when compiling Zig itself with rules_zig
+        canonical_name = "std" if ctx.label.name == "std" else escape_label(label = ctx.label),
         main = ctx.file.main,
         srcs = ctx.files.srcs,
         extra_srcs = ctx.files.extra_srcs,


### PR DESCRIPTION
This is a small one but required to build Zig with `rules_zig` instead since we have to do a `zig_library` for std.
There is a hardcoded rule in the handling of --dep in zig that doesn't allow doing anything else but --dep=std=std.

https://codeberg.org/ziglang/zig/src/commit/5cc281e7232b9f1bc5f4d732e4a37fb5df02f780/src/main.zig#L1091-L1097