### PR TITLE
chore: force canonical name of global c module top level

### DIFF
--- a/zig/private/common/translate_c.bzl
+++ b/zig/private/common/translate_c.bzl
@@ -6,7 +6,7 @@ load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load("//zig/private/common:escape_label.bzl", "escape_label", "escape_label_str")
 load("//zig/private/providers:zig_module_info.bzl", "zig_module_info")
 
-def zig_translate_c(*, ctx, name, zigtoolchaininfo, global_args, cc_infos, output_prefix = ""):
+def zig_translate_c(*, ctx, name, canonical_name = None, zigtoolchaininfo, global_args, cc_infos, output_prefix = ""):
     """Handle translate-c build action.
 
     Sets the appropriate command-line flags for the Zig compiler to expose
@@ -15,6 +15,7 @@ def zig_translate_c(*, ctx, name, zigtoolchaininfo, global_args, cc_infos, outpu
     Args:
       ctx: Context object.
       name: String, the name of the resulting Zig module.
+      canonical_name: String or None, optional canonical name override for the resulting Zig module.
       zigtoolchaininfo: ZigToolchainInfo.
       global_args: Args; mutable, Append the global Zig command-line flags to this object.
       cc_infos: List of CcInfo, The CcInfo providers for the C dependencies.
@@ -93,7 +94,7 @@ def zig_translate_c(*, ctx, name, zigtoolchaininfo, global_args, cc_infos, outpu
         # To avoid collisions, we need to escape both label and name,
         # joined using a separator that cannot appear in escapted text.
         # (here "__" is used as separator, since "_" is escaped as "_U").
-        canonical_name = "{}__{}".format(escape_label(label = ctx.label), escape_label_str(name)),
+        canonical_name = canonical_name if canonical_name else "{}__{}".format(escape_label(label = ctx.label), escape_label_str(name)),
         main = zig_out,
         cdeps = [cc_info],
     )

--- a/zig/private/common/zig_build.bzl
+++ b/zig/private/common/zig_build.bzl
@@ -405,6 +405,7 @@ def zig_build_impl(ctx, *, kind):
         c_module = zig_translate_c(
             ctx = ctx,
             name = "c",
+            canonical_name = "c",
             zigtoolchaininfo = zigtoolchaininfo,
             global_args = global_args,
             cc_infos = [root_module.cc_info],

--- a/zig/private/common/zig_docs.bzl
+++ b/zig/private/common/zig_docs.bzl
@@ -144,6 +144,7 @@ def zig_docs_impl(ctx, *, kind):
         c_module = zig_translate_c(
             ctx = ctx,
             name = "c",
+            canonical_name = "c",
             zigtoolchaininfo = zigtoolchaininfo,
             global_args = global_args,
             cc_infos = [root_module.cc_info],

--- a/zig/private/providers/zig_module_info.bzl
+++ b/zig/private/providers/zig_module_info.bzl
@@ -97,5 +97,5 @@ def zig_module_specifications(*, root_module, args, c_module = None):
     args.add_all(root_module.transitive_module_contexts, map_each = _render_per_module_args)
 
     if c_module:
-        # Global C module has a predefined canonical name.
-        args.add(c_module.module_context.main, format = "-Mc=%s")
+        args.add_all(_render_per_module_args(c_module.module_context))
+        args.add_all(c_module.transitive_module_contexts, map_each = _render_per_module_args)

--- a/zig/tests/module_info_test.bzl
+++ b/zig/tests/module_info_test.bzl
@@ -305,7 +305,10 @@ def _write_simple_module_with_global_c_expected_specs_args_impl(ctx):
         src = mods["data_global_c"].module_context.main,
     )])
     expected.extend(bazel_builtins["data_global_c"].mod_flags)
-    expected.extend(["'-Mc={}'".format(mods["data_c_zig"].module_context.main)])
+    expected.extend(["'-M{name}={src}'".format(
+        name = mods["data_c_zig"].canonical_name,
+        src = mods["data_c_zig"].module_context.main,
+    )])
 
     ctx.actions.write(
         output = ctx.outputs.out,


### PR DESCRIPTION
This makes it more explicit than relying on -Mc= downstream. Now, all mention of global "c" is through "canonical_name" = "c" and is treated in module spec just like any other module.

This is a prerequisite for translate-c from source since the "c" module will have dependencies itself (builtins).