### PR TITLE
chore: reuse escape_label for bazel builtin names

### DIFF
--- a/zig/private/common/BUILD.bazel
+++ b/zig/private/common/BUILD.bazel
@@ -80,7 +80,10 @@ bzl_library(
     name = "bazel_builtin",
     srcs = ["bazel_builtin.bzl"],
     visibility = ["//zig:__subpackages__"],
-    deps = ["//zig/private/providers:zig_module_info"],
+    deps = [
+        ":escape_label",
+        "//zig/private/providers:zig_module_info",
+    ],
 )
 
 bzl_library(

--- a/zig/private/common/bazel_builtin.bzl
+++ b/zig/private/common/bazel_builtin.bzl
@@ -1,10 +1,10 @@
 """Generate the `bazel_builtin` module."""
 
+load("//zig/private/common:escape_label.bzl", "escape_label")
 load(
     "//zig/private/providers:zig_module_info.bzl",
     "zig_module_info",
 )
-load("//zig/private/common:escape_label.bzl", "escape_label")
 
 ATTRS = {
     "_bazel_builtin_template": attr.label(

--- a/zig/private/common/bazel_builtin.bzl
+++ b/zig/private/common/bazel_builtin.bzl
@@ -4,6 +4,7 @@ load(
     "//zig/private/providers:zig_module_info.bzl",
     "zig_module_info",
 )
+load("//zig/private/common:escape_label.bzl", "escape_label")
 
 ATTRS = {
     "_bazel_builtin_template": attr.label(
@@ -25,11 +26,7 @@ def bazel_builtin_module(ctx):
     package_name = ctx.label.package
     target_name = ctx.label.name
 
-    name = "bazel_builtin_A{repo}_S_S{package}_C{target}".format(
-        repo = repo_name.replace("~", "_T"),
-        package = package_name.replace("/", "_S"),
-        target = target_name,
-    )
+    name = "bazel_builtin_" + escape_label(label = ctx.label)
     main = ctx.actions.declare_file(name + ".zig")
 
     substitutions = ctx.actions.template_dict()

--- a/zig/tests/module_info_test.bzl
+++ b/zig/tests/module_info_test.bzl
@@ -3,35 +3,32 @@
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
+load("//zig/private/common:escape_label.bzl", "escape_label")
 load(
     "//zig/private/providers:zig_module_info.bzl",
     "ZigModuleInfo",
     "zig_module_specifications",
 )
 
-def _bazel_builtin_name(label):
-    return "bazel_builtin_A{repo}_S_S{package}_C{target}".format(
-        repo = label.repo_name if hasattr(label, "repo_name") else label.workspace_name,
-        package = label.package.replace("/", "_S"),
-        target = label.name,
-    )
+def _bazel_builtin_canonical_name(label):
+    return "bazel_builtin_" + escape_label(label = label)
 
 def _bazel_builtin_file_name(ctx, label):
     return paths.join(
         ctx.bin_dir.path,
         label.workspace_root,
         label.package,
-        _bazel_builtin_name(label) + ".zig",
+        _bazel_builtin_canonical_name(label) + ".zig",
     )
 
 def _bazel_builtin_mod_flags(ctx, label):
     return ["'-M{}={}'".format(
-        _bazel_builtin_name(label),
+        _bazel_builtin_canonical_name(label),
         _bazel_builtin_file_name(ctx, label),
     )]
 
 def _bazel_builtin_dep(label):
-    return "'bazel_builtin={}'".format(_bazel_builtin_name(label))
+    return "'bazel_builtin={}'".format(_bazel_builtin_canonical_name(label))
 
 def _write_simple_module_expected_specs_args_impl(ctx):
     mod = ctx.attr.mod[ZigModuleInfo]


### PR DESCRIPTION
So that we share a single way of mangling canonical deps