### PR TITLE
feat: add zig exec group to all rules

### DIFF
--- a/zig/private/BUILD.bazel
+++ b/zig/private/BUILD.bazel
@@ -29,6 +29,7 @@ bzl_library(
     deps = [
         "//zig/private/common:bazel_builtin",
         "//zig/private/common:data",
+        "//zig/private/common:exec_groups",
         "//zig/private/common:filetypes",
         "//zig/private/common:translate_c",
         "//zig/private/providers:zig_module_info",

--- a/zig/private/common/BUILD.bazel
+++ b/zig/private/common/BUILD.bazel
@@ -3,12 +3,6 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 exports_files(["bazel_builtin.zig.tpl"])
 
 bzl_library(
-    name = "exec_groups",
-    srcs = ["exec_groups.bzl"],
-    visibility = ["//zig:__subpackages__"],
-)
-
-bzl_library(
     name = "zig_cache",
     srcs = ["zig_cache.bzl"],
     visibility = ["//zig:__subpackages__"],
@@ -130,6 +124,12 @@ bzl_library(
 bzl_library(
     name = "escape_label",
     srcs = ["escape_label.bzl"],
+    visibility = ["//zig:__subpackages__"],
+)
+
+bzl_library(
+    name = "exec_groups",
+    srcs = ["exec_groups.bzl"],
     visibility = ["//zig:__subpackages__"],
 )
 

--- a/zig/private/common/BUILD.bazel
+++ b/zig/private/common/BUILD.bazel
@@ -3,6 +3,12 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 exports_files(["bazel_builtin.zig.tpl"])
 
 bzl_library(
+    name = "exec_groups",
+    srcs = ["exec_groups.bzl"],
+    visibility = ["//zig:__subpackages__"],
+)
+
+bzl_library(
     name = "zig_cache",
     srcs = ["zig_cache.bzl"],
     visibility = ["//zig:__subpackages__"],
@@ -26,6 +32,7 @@ bzl_library(
         ":csrcs",
         ":data",
         ":escape_label",
+        ":exec_groups",
         ":filetypes",
         ":linker_script",
         ":location_expansion",
@@ -54,6 +61,7 @@ bzl_library(
         ":cdeps",
         ":csrcs",
         ":escape_label",
+        ":exec_groups",
         ":location_expansion",
         ":translate_c",
         ":zig_cache",
@@ -97,6 +105,7 @@ bzl_library(
     visibility = ["//zig:__subpackages__"],
     deps = [
         ":escape_label",
+        ":exec_groups",
         "//zig/private:cc_helper",
         "//zig/private/providers:zig_module_info",
         "//zig/private/providers:zig_toolchain_info",
@@ -159,6 +168,7 @@ filegroup(
         ":csrcs.bzl",
         ":data.bzl",
         ":escape_label.bzl",
+        ":exec_groups.bzl",
         ":filetypes.bzl",
         ":linker_script.bzl",
         ":location_expansion.bzl",

--- a/zig/private/common/exec_groups.bzl
+++ b/zig/private/common/exec_groups.bzl
@@ -12,23 +12,19 @@ ZIG_EXEC_GROUPS = {
 }
 
 def zig_exec_group_toolchain(ctx):
-    if hasattr(ctx, "exec_groups") and ZIG_EXEC_GROUP in ctx.exec_groups:
-        return ctx.exec_groups[ZIG_EXEC_GROUP].toolchains[ZIG_TOOLCHAIN_TYPE].zigtoolchaininfo
-    return ctx.toolchains[ZIG_TOOLCHAIN_TYPE].zigtoolchaininfo
+    return ctx.exec_groups[ZIG_EXEC_GROUP].toolchains[ZIG_TOOLCHAIN_TYPE].zigtoolchaininfo
 
 def zig_exec_group_action_kwargs(ctx):
-    kwargs = {"toolchain": ZIG_TOOLCHAIN_TYPE}
-    if hasattr(ctx, "exec_groups") and ZIG_EXEC_GROUP in ctx.exec_groups:
-        kwargs["exec_group"] = ZIG_EXEC_GROUP
-    return kwargs
+    return {
+        "exec_group": ZIG_EXEC_GROUP,
+        "toolchain": ZIG_TOOLCHAIN_TYPE,
+    }
 
 def translate_c_exec_group_toolchain(ctx):
-    if hasattr(ctx, "exec_groups") and ZIG_EXEC_GROUP in ctx.exec_groups:
-        return ctx.exec_groups[ZIG_EXEC_GROUP].toolchains[TRANSLATE_C_TOOLCHAIN_TYPE]
-    return ctx.toolchains[TRANSLATE_C_TOOLCHAIN_TYPE]
+    return ctx.exec_groups[ZIG_EXEC_GROUP].toolchains[TRANSLATE_C_TOOLCHAIN_TYPE]
 
 def translate_c_exec_group_action_kwargs(ctx):
-    kwargs = {"toolchain": TRANSLATE_C_TOOLCHAIN_TYPE}
-    if hasattr(ctx, "exec_groups") and ZIG_EXEC_GROUP in ctx.exec_groups:
-        kwargs["exec_group"] = ZIG_EXEC_GROUP
-    return kwargs
+    return {
+        "exec_group": ZIG_EXEC_GROUP,
+        "toolchain": TRANSLATE_C_TOOLCHAIN_TYPE,
+    }

--- a/zig/private/common/exec_groups.bzl
+++ b/zig/private/common/exec_groups.bzl
@@ -14,7 +14,7 @@ ZIG_EXEC_GROUPS = {
 def zig_exec_group_toolchain(ctx):
     return ctx.exec_groups[ZIG_EXEC_GROUP].toolchains[ZIG_TOOLCHAIN_TYPE].zigtoolchaininfo
 
-def zig_exec_group_action_kwargs(ctx):
+def zig_exec_group_action_kwargs():
     return {
         "exec_group": ZIG_EXEC_GROUP,
         "toolchain": ZIG_TOOLCHAIN_TYPE,
@@ -23,7 +23,7 @@ def zig_exec_group_action_kwargs(ctx):
 def translate_c_exec_group_toolchain(ctx):
     return ctx.exec_groups[ZIG_EXEC_GROUP].toolchains[TRANSLATE_C_TOOLCHAIN_TYPE]
 
-def translate_c_exec_group_action_kwargs(ctx):
+def translate_c_exec_group_action_kwargs():
     return {
         "exec_group": ZIG_EXEC_GROUP,
         "toolchain": TRANSLATE_C_TOOLCHAIN_TYPE,

--- a/zig/private/common/exec_groups.bzl
+++ b/zig/private/common/exec_groups.bzl
@@ -1,0 +1,34 @@
+"""Execution groups shared by Zig rules."""
+
+ZIG_EXEC_GROUP = "zig"
+ZIG_TOOLCHAIN_TYPE = "//zig:toolchain_type"
+TRANSLATE_C_TOOLCHAIN_TYPE = "//zig/translate-c:toolchain_type"
+
+ZIG_EXEC_GROUPS = {
+    ZIG_EXEC_GROUP: exec_group(toolchains = [
+        ZIG_TOOLCHAIN_TYPE,
+        config_common.toolchain_type(TRANSLATE_C_TOOLCHAIN_TYPE, mandatory = False),
+    ]),
+}
+
+def zig_exec_group_toolchain(ctx):
+    if hasattr(ctx, "exec_groups") and ZIG_EXEC_GROUP in ctx.exec_groups:
+        return ctx.exec_groups[ZIG_EXEC_GROUP].toolchains[ZIG_TOOLCHAIN_TYPE].zigtoolchaininfo
+    return ctx.toolchains[ZIG_TOOLCHAIN_TYPE].zigtoolchaininfo
+
+def zig_exec_group_action_kwargs(ctx):
+    kwargs = {"toolchain": ZIG_TOOLCHAIN_TYPE}
+    if hasattr(ctx, "exec_groups") and ZIG_EXEC_GROUP in ctx.exec_groups:
+        kwargs["exec_group"] = ZIG_EXEC_GROUP
+    return kwargs
+
+def translate_c_exec_group_toolchain(ctx):
+    if hasattr(ctx, "exec_groups") and ZIG_EXEC_GROUP in ctx.exec_groups:
+        return ctx.exec_groups[ZIG_EXEC_GROUP].toolchains[TRANSLATE_C_TOOLCHAIN_TYPE]
+    return ctx.toolchains[TRANSLATE_C_TOOLCHAIN_TYPE]
+
+def translate_c_exec_group_action_kwargs(ctx):
+    kwargs = {"toolchain": TRANSLATE_C_TOOLCHAIN_TYPE}
+    if hasattr(ctx, "exec_groups") and ZIG_EXEC_GROUP in ctx.exec_groups:
+        kwargs["exec_group"] = ZIG_EXEC_GROUP
+    return kwargs

--- a/zig/private/common/translate_c.bzl
+++ b/zig/private/common/translate_c.bzl
@@ -144,7 +144,7 @@ def _builtin_translate_c(*, ctx, zigtoolchaininfo, global_args, compilation_cont
             "ZIG_LOCAL_CACHE_DIR": zigtoolchaininfo.zig_cache,
         },
         tools = [zigtoolchaininfo.zig_exe.file] if zigtoolchaininfo.zig_exe.file else [],
-        **zig_exec_group_action_kwargs(ctx)
+        **zig_exec_group_action_kwargs()
     )
 
     return zig_out, []
@@ -265,7 +265,7 @@ def _external_translate_c(*, ctx, translatectoolchaininfo, compilation_context, 
             xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
             xcode_path_resolve_level = apple_support.xcode_path_resolve_level.args,
         )
-    actions_run_extra_kwargs.update(translate_c_exec_group_action_kwargs(ctx))
+    actions_run_extra_kwargs.update(translate_c_exec_group_action_kwargs())
 
     actions_run(
         inputs = depset(

--- a/zig/private/common/translate_c.bzl
+++ b/zig/private/common/translate_c.bzl
@@ -7,6 +7,11 @@ load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load("//zig/private:cc_helper.bzl", "find_cc_toolchain")
 load("//zig/private/common:escape_label.bzl", "escape_label", "escape_label_str")
+load(
+    "//zig/private/common:exec_groups.bzl",
+    "translate_c_exec_group_action_kwargs",
+    "zig_exec_group_action_kwargs",
+)
 load("//zig/private/providers:zig_module_info.bzl", "zig_module_info")
 load(
     "//zig/private/providers:zig_toolchain_info.bzl",
@@ -139,7 +144,7 @@ def _builtin_translate_c(*, ctx, zigtoolchaininfo, global_args, compilation_cont
             "ZIG_LOCAL_CACHE_DIR": zigtoolchaininfo.zig_cache,
         },
         tools = [zigtoolchaininfo.zig_exe.file] if zigtoolchaininfo.zig_exe.file else [],
-        toolchain = "//zig:toolchain_type",
+        **zig_exec_group_action_kwargs(ctx)
     )
 
     return zig_out, []
@@ -260,6 +265,7 @@ def _external_translate_c(*, ctx, translatectoolchaininfo, compilation_context, 
             xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
             xcode_path_resolve_level = apple_support.xcode_path_resolve_level.args,
         )
+    actions_run_extra_kwargs.update(translate_c_exec_group_action_kwargs(ctx))
 
     actions_run(
         inputs = depset(
@@ -273,7 +279,6 @@ def _external_translate_c(*, ctx, translatectoolchaininfo, compilation_context, 
         progress_message = "zig translate-c %{label}",
         execution_requirements = {tag: "" for tag in ctx.attr.tags},
         tools = [translatectoolchaininfo.files_to_run],
-        toolchain = "//zig:toolchain_type",
         **actions_run_extra_kwargs
     )
 

--- a/zig/private/common/zig_build.bzl
+++ b/zig/private/common/zig_build.bzl
@@ -484,7 +484,7 @@ def zig_build_impl(ctx, *, kind):
             "ZIG_GLOBAL_CACHE_DIR": zigtoolchaininfo.zig_cache,
             "ZIG_LOCAL_CACHE_DIR": zigtoolchaininfo.zig_cache,
         },
-    ) | zig_exec_group_action_kwargs(ctx)
+    ) | zig_exec_group_action_kwargs()
 
     linkopts = location_expansion(
         ctx = ctx,

--- a/zig/private/common/zig_build.bzl
+++ b/zig/private/common/zig_build.bzl
@@ -16,6 +16,13 @@ load("//zig/private/common:csrcs.bzl", "zig_csrcs")
 load("//zig/private/common:data.bzl", "zig_collect_data", "zig_create_runfiles")
 load("//zig/private/common:escape_label.bzl", "escape_label")
 load(
+    "//zig/private/common:exec_groups.bzl",
+    "ZIG_EXEC_GROUPS",
+    "translate_c_exec_group_toolchain",
+    "zig_exec_group_action_kwargs",
+    "zig_exec_group_toolchain",
+)
+load(
     "//zig/private/common:filetypes.bzl",
     "ZIG_C_SOURCE_EXTENSIONS",
     "ZIG_SOURCE_EXTENSIONS",
@@ -201,10 +208,10 @@ Environment variables to inherit from external environment when executed by `baz
 } | COMMON_EMIT_ATTRS
 
 TOOLCHAINS = [
-    "//zig:toolchain_type",
     "//zig/target:toolchain_type",
-    config_common.toolchain_type("//zig/translate-c:toolchain_type", mandatory = False),
 ] + use_cc_toolchain(mandatory = False)
+
+EXEC_GROUPS = ZIG_EXEC_GROUPS
 
 FRAGMENTS = ["cpp"]
 
@@ -249,9 +256,9 @@ def zig_build_impl(ctx, *, kind):
         if not (ctx.attr.emit_bin or ctx.attr.emit_asm or ctx.attr.emit_llvm_ir or ctx.attr.emit_llvm_bc):
             fail("At least one emitted output must be enabled.")
 
-    zigtoolchaininfo = ctx.toolchains["//zig:toolchain_type"].zigtoolchaininfo
+    zigtoolchaininfo = zig_exec_group_toolchain(ctx)
     zigtargetinfo = ctx.toolchains["//zig/target:toolchain_type"].zigtargetinfo
-    translate_c_toolchain = ctx.toolchains["//zig/translate-c:toolchain_type"]
+    translate_c_toolchain = translate_c_exec_group_toolchain(ctx)
     translatectoolchaininfo = translate_c_toolchain.translatectoolchaininfo if translate_c_toolchain else None
 
     use_cc_common_link = ctx.attr._settings[ZigSettingsInfo].use_cc_common_link
@@ -473,12 +480,11 @@ def zig_build_impl(ctx, *, kind):
 
     zig_build_kwargs = dict(
         execution_requirements = {tag: "" for tag in ctx.attr.tags},
-        toolchain = "//zig:toolchain_type",
         env = {
             "ZIG_GLOBAL_CACHE_DIR": zigtoolchaininfo.zig_cache,
             "ZIG_LOCAL_CACHE_DIR": zigtoolchaininfo.zig_cache,
         },
-    )
+    ) | zig_exec_group_action_kwargs(ctx)
 
     linkopts = location_expansion(
         ctx = ctx,

--- a/zig/private/common/zig_docs.bzl
+++ b/zig/private/common/zig_docs.bzl
@@ -205,7 +205,7 @@ def zig_docs_impl(ctx, *, kind):
         mnemonic = mnemonic,
         progress_message = progress_message,
         execution_requirements = {tag: "" for tag in ctx.attr.tags},
-        **zig_exec_group_action_kwargs(ctx)
+        **zig_exec_group_action_kwargs()
     )
 
     providers = []

--- a/zig/private/common/zig_docs.bzl
+++ b/zig/private/common/zig_docs.bzl
@@ -8,6 +8,12 @@ load(
 )
 load("//zig/private/common:csrcs.bzl", "zig_csrcs")
 load("//zig/private/common:escape_label.bzl", "escape_label")
+load(
+    "//zig/private/common:exec_groups.bzl",
+    "translate_c_exec_group_toolchain",
+    "zig_exec_group_action_kwargs",
+    "zig_exec_group_toolchain",
+)
 load("//zig/private/common:location_expansion.bzl", "location_expansion")
 load("//zig/private/common:translate_c.bzl", "zig_translate_c")
 load("//zig/private/common:zig_cache.bzl", "zig_cache_output")
@@ -59,9 +65,9 @@ def zig_docs_impl(ctx, *, kind):
         if len(ctx.attr.csrcs) > 0:
             fail("'csrcs' cannot be set without a 'main'. They are taken from the root module defined by the single zig dependency.")
 
-    zigtoolchaininfo = ctx.toolchains["//zig:toolchain_type"].zigtoolchaininfo
+    zigtoolchaininfo = zig_exec_group_toolchain(ctx)
     zigtargetinfo = ctx.toolchains["//zig/target:toolchain_type"].zigtargetinfo
-    translate_c_toolchain = ctx.toolchains["//zig/translate-c:toolchain_type"]
+    translate_c_toolchain = translate_c_exec_group_toolchain(ctx)
     translatectoolchaininfo = translate_c_toolchain.translatectoolchaininfo if translate_c_toolchain else None
 
     files = None
@@ -199,6 +205,7 @@ def zig_docs_impl(ctx, *, kind):
         mnemonic = mnemonic,
         progress_message = progress_message,
         execution_requirements = {tag: "" for tag in ctx.attr.tags},
+        **zig_exec_group_action_kwargs(ctx)
     )
 
     providers = []

--- a/zig/private/zig_binary.bzl
+++ b/zig/private/zig_binary.bzl
@@ -4,6 +4,7 @@ load("@apple_support//lib:apple_support.bzl", "apple_support")
 load(
     "//zig/private/common:zig_build.bzl",
     "BINARY_ATTRS",
+    "EXEC_GROUPS",
     "zig_build_impl",
     COMMON_ATTRS = "ATTRS",
     COMMON_FRAGMENTS = "FRAGMENTS",
@@ -60,5 +61,6 @@ zig_binary = rule(
     doc = DOC,
     executable = True,
     toolchains = TOOLCHAINS,
+    exec_groups = EXEC_GROUPS,
     fragments = FRAGMENTS,
 )

--- a/zig/private/zig_c_library.bzl
+++ b/zig/private/zig_c_library.bzl
@@ -8,6 +8,12 @@ load(
     BAZEL_BUILTIN_ATTRS = "ATTRS",
 )
 load("//zig/private/common:data.bzl", "zig_collect_data", "zig_create_runfiles")
+load(
+    "//zig/private/common:exec_groups.bzl",
+    "ZIG_EXEC_GROUPS",
+    "translate_c_exec_group_toolchain",
+    "zig_exec_group_toolchain",
+)
 load("//zig/private/common:translate_c.bzl", "zig_translate_c")
 load("//zig/private/common:zig_cache.bzl", "zig_cache_output")
 load("//zig/private/common:zig_lib_dir.bzl", "zig_lib_dir")
@@ -55,16 +61,15 @@ ATTRS = {
     ),
 } | BAZEL_BUILTIN_ATTRS | apple_support.action_required_attrs()
 
-TOOLCHAINS = [
-    "//zig:toolchain_type",
-    config_common.toolchain_type("//zig/translate-c:toolchain_type", mandatory = False),
-] + use_cc_toolchain(mandatory = False)
+TOOLCHAINS = use_cc_toolchain(mandatory = False)
+
+EXEC_GROUPS = ZIG_EXEC_GROUPS
 
 FRAGMENTS = ["apple", "cpp"]
 
 def _zig_c_library_impl(ctx):
-    zigtoolchaininfo = ctx.toolchains["//zig:toolchain_type"].zigtoolchaininfo
-    translate_c_toolchain = ctx.toolchains["//zig/translate-c:toolchain_type"]
+    zigtoolchaininfo = zig_exec_group_toolchain(ctx)
+    translate_c_toolchain = translate_c_exec_group_toolchain(ctx)
     translatectoolchaininfo = translate_c_toolchain.translatectoolchaininfo if translate_c_toolchain else None
 
     transitive_data = []
@@ -116,5 +121,6 @@ zig_c_library = rule(
     attrs = ATTRS,
     doc = DOC,
     toolchains = TOOLCHAINS,
+    exec_groups = EXEC_GROUPS,
     fragments = FRAGMENTS,
 )

--- a/zig/private/zig_shared_library.bzl
+++ b/zig/private/zig_shared_library.bzl
@@ -2,6 +2,7 @@
 
 load(
     "//zig/private/common:zig_build.bzl",
+    "EXEC_GROUPS",
     "SHARED_LIBRARY_ATTRS",
     "zig_build_impl",
     COMMON_ATTRS = "ATTRS",
@@ -58,5 +59,6 @@ zig_shared_library = rule(
     attrs = ATTRS,
     doc = DOC,
     toolchains = TOOLCHAINS,
+    exec_groups = EXEC_GROUPS,
     fragments = FRAGMENTS,
 )

--- a/zig/private/zig_static_library.bzl
+++ b/zig/private/zig_static_library.bzl
@@ -2,6 +2,7 @@
 
 load(
     "//zig/private/common:zig_build.bzl",
+    "EXEC_GROUPS",
     "STATIC_LIBRARY_ATTRS",
     "zig_build_impl",
     COMMON_ATTRS = "ATTRS",
@@ -58,5 +59,6 @@ zig_static_library = rule(
     attrs = ATTRS,
     doc = DOC,
     toolchains = TOOLCHAINS,
+    exec_groups = EXEC_GROUPS,
     fragments = FRAGMENTS,
 )

--- a/zig/private/zig_test.bzl
+++ b/zig/private/zig_test.bzl
@@ -3,6 +3,7 @@
 load("@apple_support//lib:apple_support.bzl", "apple_support")
 load(
     "//zig/private/common:zig_build.bzl",
+    "EXEC_GROUPS",
     "TEST_ATTRS",
     "zig_build_impl",
     COMMON_ATTRS = "ATTRS",
@@ -58,5 +59,6 @@ zig_test = rule(
     doc = DOC,
     test = True,
     toolchains = TOOLCHAINS,
+    exec_groups = EXEC_GROUPS,
     fragments = FRAGMENTS,
 )


### PR DESCRIPTION
Adds a dedicated `zig` exec group for Zig rule actions.

## Motivation

This lets downstream repos make Zig actions run on a distinct execution platform without moving the rule’s default execution platform. In particular, remote builds can keep non-Zig actions on the normal remote platform while forcing Zig actions onto a local platform when needed.