### PR TITLE
feat: globally register ZLS index and toolchains

### DIFF
--- a/.github/scripts/release_prep.sh
+++ b/.github/scripts/release_prep.sh
@@ -23,11 +23,20 @@ bazel_dep(name = "rules_zig", version = "$VERSION")
 Optionally add the following to your \`MODULE.bazel\` file to install a specific Zig toolchain version:
 
 \`\`\`starlark
-zig = use_extension("//zig:extensions.bzl", "zig")
+zig = use_extension("@rules_zig//zig:extensions.bzl", "zig")
 zig.toolchain(zig_version = "0.16.0")
 \`\`\`
 
 You can call \`zig.toolchain\` multiple times to install multiple Zig versions.
+
+Optionally add the following to your \`MODULE.bazel\` file to install a specific ZLS toolchain version and declare what Zig version it applies to:
+
+\`\`\`starlark
+zls = use_extension("@rules_zig//zig/zls:extensions.bzl", "zls")
+zls.toolchain(zig_version = "0.16.0", zls_version = "0.16.0")
+\`\`\`
+
+You can call \`zls.toolchain\` multiple times to install multiple ZLS versions.
 
 Note, rules_zig requires bzlmod, WORKSPACE mode is no longer supported.
 EOF

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -35,6 +35,12 @@ register_toolchains("@rules_zig//zig/target:all")
 
 register_toolchains("@zig_toolchains//:all")
 
+zls = use_extension("//zig/zls:extensions.bzl", "zls")
+zls.index(file = "//zig/zls/private:versions.json")
+use_repo(zls, "zls_toolchains")
+
+register_toolchains("@zls_toolchains//:all")
+
 zig_dev = use_extension(
     "//zig:extensions.bzl",
     "zig",
@@ -48,7 +54,6 @@ zls_dev = use_extension(
     "zls",
     dev_dependency = True,
 )
-zls_dev.index(file = "//zig/zls/private:versions.json")
 zls_dev.toolchain(
     zig_version = "0.16.0",
     zls_version = "0.16.0",
@@ -56,12 +61,6 @@ zls_dev.toolchain(
 zls_dev.toolchain(
     zig_version = "0.15.2",
     zls_version = "0.15.1",
-)
-use_repo(zls_dev, "zls_toolchains")
-
-register_toolchains(
-    "@zls_toolchains//:all",
-    dev_dependency = True,
 )
 
 bazel_dep(name = "toolchains_buildbuddy", version = "0.0.4", dev_dependency = True)

--- a/zig/zls/private/bzlmod/zls.bzl
+++ b/zig/zls/private/bzlmod/zls.bzl
@@ -156,9 +156,6 @@ def _toolchain_extension(module_ctx):
     if err != None:
         fail(*err)
 
-    if len(mappings) == 0:
-        fail("The zls extension requires at least one zls.toolchain tag.")
-
     toolchain_names = []
     toolchain_labels = []
     toolchain_zig_versions = []
@@ -194,9 +191,6 @@ def _toolchain_extension(module_ctx):
                     zls_version = mapping.zls_version,
                     platform = platform,
                 )
-
-    if len(toolchain_names) == 0:
-        fail("No ZLS toolchains were generated. Check that the requested ZLS versions have entries for supported platforms.")
 
     toolchains_repo(
         name = _DEFAULT_NAME + "_toolchains",


### PR DESCRIPTION
Move that extension out of dev-dependency mode so that it also applies for downstream users when rules_zig is not the root module.

Note, this drops the requirement for at least one registered ZLS toolchain.