### PR TITLE
feat: support mapping Zig mode to Bazel compilation mode

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -130,6 +130,8 @@ Transitions a target and its dependencies to a different configuration.
 Settings like the build mode, e.g. `ReleaseSafe`, or the target platform,
 can be set on the command-line on demand,
 e.g. using `--@rules_zig//zig/settings:mode=release_safe`.
+By default, target build mode is `auto`: Bazel `dbg` and `fastbuild`
+compilation modes map to Zig `Debug`, and Bazel `opt` maps to Zig `ReleaseFast`.
 
 However, you may wish to always build a given target
 in a particular configuration,
@@ -174,11 +176,11 @@ zig_configure(
 | <a id="zig_configure-actual"></a>actual |  The target to transition.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
 | <a id="zig_configure-bootstrapped"></a>bootstrapped |  Whether to use a bootstrapped Zig compiler. Possible values: [-1, 0, 1]. -1 means use current configuration value for //zig/settings:bootstrapped. 0 means do not use a bootstrapped Zig compiler. 1 means use a bootstrapped Zig compiler.   | Integer | optional |  `-1`  |
 | <a id="zig_configure-extra_toolchains"></a>extra_toolchains |  Additional toolchains to consider during toolchain resolution for the transitioned target.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
-| <a id="zig_configure-host_mode"></a>host_mode |  The build mode setting for the host configuration, corresponds to the `-O` Zig compiler flag.   | String | optional |  `""`  |
+| <a id="zig_configure-host_mode"></a>host_mode |  The build mode setting for the host configuration, corresponds to the `-O` Zig compiler flag. `auto` follows Bazel's `--compilation_mode`.   | String | optional |  `""`  |
 | <a id="zig_configure-host_threaded"></a>host_threaded |  The threaded setting for the host configuration, corresponds to the `-fsingle-threaded` Zig compiler flag.   | String | optional |  `""`  |
 | <a id="zig_configure-host_use_cc_common_link"></a>host_use_cc_common_link |  Whether to use cc_common.link to link zig binaries, tests and shared libraries in the host configuration. Possible values: [-1, 0, 1]. -1 means use current host configuration value for //zig/settings:host_use_cc_common_link. 0 means do not use cc_common.link (use zig build-exe instead). 1 means use cc_common.link.   | Integer | optional |  `-1`  |
 | <a id="zig_configure-host_zigopt"></a>host_zigopt |  Additional list of flags passed to the zig compiler for all Zig compile actions when building for the host configuration.<br><br>The flags specified by this setting do not override those specified via the `zigopts` attribute of `zig_*` rules. Instead, they are prepended to the command line before module specific flags.<br><br>This is an advanced feature that can conflict with attributes, build settings, and other flags defined by the toolchain itself. Use this at your own risk of hitting undefined behaviors.   | List of strings | optional |  `[]`  |
-| <a id="zig_configure-mode"></a>mode |  The build mode setting, corresponds to the `-O` Zig compiler flag.   | String | optional |  `""`  |
+| <a id="zig_configure-mode"></a>mode |  The build mode setting, corresponds to the `-O` Zig compiler flag. `auto` follows Bazel's `--compilation_mode`.   | String | optional |  `""`  |
 | <a id="zig_configure-target"></a>target |  The target platform, expects a label to a Bazel target platform used to select a `zig_target_toolchain` instance.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="zig_configure-threaded"></a>threaded |  The threaded setting, corresponds to the `-fsingle-threaded` Zig compiler flag.   | String | optional |  `""`  |
 | <a id="zig_configure-use_cc_common_link"></a>use_cc_common_link |  Whether to use cc_common.link to link zig binaries, tests and shared libraries. Possible values: [-1, 0, 1]. -1 means use current configuration value for //zig/settings:experimental_use_cc_common_link. 0 means do not use cc_common.link (use zig build-exe instead). 1 means use cc_common.link.   | Integer | optional |  `-1`  |
@@ -204,6 +206,8 @@ Transitions a target and its dependencies to a different configuration.
 Settings like the build mode, e.g. `ReleaseSafe`, or the target platform,
 can be set on the command-line on demand,
 e.g. using `--@rules_zig//zig/settings:mode=release_safe`.
+By default, target build mode is `auto`: Bazel `dbg` and `fastbuild`
+compilation modes map to Zig `Debug`, and Bazel `opt` maps to Zig `ReleaseFast`.
 
 However, you may wish to always build a given target
 in a particular configuration,
@@ -248,11 +252,11 @@ zig_configure_binary(
 | <a id="zig_configure_binary-actual"></a>actual |  The target to transition.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
 | <a id="zig_configure_binary-bootstrapped"></a>bootstrapped |  Whether to use a bootstrapped Zig compiler. Possible values: [-1, 0, 1]. -1 means use current configuration value for //zig/settings:bootstrapped. 0 means do not use a bootstrapped Zig compiler. 1 means use a bootstrapped Zig compiler.   | Integer | optional |  `-1`  |
 | <a id="zig_configure_binary-extra_toolchains"></a>extra_toolchains |  Additional toolchains to consider during toolchain resolution for the transitioned target.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
-| <a id="zig_configure_binary-host_mode"></a>host_mode |  The build mode setting for the host configuration, corresponds to the `-O` Zig compiler flag.   | String | optional |  `""`  |
+| <a id="zig_configure_binary-host_mode"></a>host_mode |  The build mode setting for the host configuration, corresponds to the `-O` Zig compiler flag. `auto` follows Bazel's `--compilation_mode`.   | String | optional |  `""`  |
 | <a id="zig_configure_binary-host_threaded"></a>host_threaded |  The threaded setting for the host configuration, corresponds to the `-fsingle-threaded` Zig compiler flag.   | String | optional |  `""`  |
 | <a id="zig_configure_binary-host_use_cc_common_link"></a>host_use_cc_common_link |  Whether to use cc_common.link to link zig binaries, tests and shared libraries in the host configuration. Possible values: [-1, 0, 1]. -1 means use current host configuration value for //zig/settings:host_use_cc_common_link. 0 means do not use cc_common.link (use zig build-exe instead). 1 means use cc_common.link.   | Integer | optional |  `-1`  |
 | <a id="zig_configure_binary-host_zigopt"></a>host_zigopt |  Additional list of flags passed to the zig compiler for all Zig compile actions when building for the host configuration.<br><br>The flags specified by this setting do not override those specified via the `zigopts` attribute of `zig_*` rules. Instead, they are prepended to the command line before module specific flags.<br><br>This is an advanced feature that can conflict with attributes, build settings, and other flags defined by the toolchain itself. Use this at your own risk of hitting undefined behaviors.   | List of strings | optional |  `[]`  |
-| <a id="zig_configure_binary-mode"></a>mode |  The build mode setting, corresponds to the `-O` Zig compiler flag.   | String | optional |  `""`  |
+| <a id="zig_configure_binary-mode"></a>mode |  The build mode setting, corresponds to the `-O` Zig compiler flag. `auto` follows Bazel's `--compilation_mode`.   | String | optional |  `""`  |
 | <a id="zig_configure_binary-target"></a>target |  The target platform, expects a label to a Bazel target platform used to select a `zig_target_toolchain` instance.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="zig_configure_binary-threaded"></a>threaded |  The threaded setting, corresponds to the `-fsingle-threaded` Zig compiler flag.   | String | optional |  `""`  |
 | <a id="zig_configure_binary-use_cc_common_link"></a>use_cc_common_link |  Whether to use cc_common.link to link zig binaries, tests and shared libraries. Possible values: [-1, 0, 1]. -1 means use current configuration value for //zig/settings:experimental_use_cc_common_link. 0 means do not use cc_common.link (use zig build-exe instead). 1 means use cc_common.link.   | Integer | optional |  `-1`  |
@@ -278,6 +282,8 @@ Transitions a target and its dependencies to a different configuration.
 Settings like the build mode, e.g. `ReleaseSafe`, or the target platform,
 can be set on the command-line on demand,
 e.g. using `--@rules_zig//zig/settings:mode=release_safe`.
+By default, target build mode is `auto`: Bazel `dbg` and `fastbuild`
+compilation modes map to Zig `Debug`, and Bazel `opt` maps to Zig `ReleaseFast`.
 
 However, you may wish to always build a given target
 in a particular configuration,
@@ -322,11 +328,11 @@ zig_configure_test(
 | <a id="zig_configure_test-actual"></a>actual |  The target to transition.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
 | <a id="zig_configure_test-bootstrapped"></a>bootstrapped |  Whether to use a bootstrapped Zig compiler. Possible values: [-1, 0, 1]. -1 means use current configuration value for //zig/settings:bootstrapped. 0 means do not use a bootstrapped Zig compiler. 1 means use a bootstrapped Zig compiler.   | Integer | optional |  `-1`  |
 | <a id="zig_configure_test-extra_toolchains"></a>extra_toolchains |  Additional toolchains to consider during toolchain resolution for the transitioned target.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
-| <a id="zig_configure_test-host_mode"></a>host_mode |  The build mode setting for the host configuration, corresponds to the `-O` Zig compiler flag.   | String | optional |  `""`  |
+| <a id="zig_configure_test-host_mode"></a>host_mode |  The build mode setting for the host configuration, corresponds to the `-O` Zig compiler flag. `auto` follows Bazel's `--compilation_mode`.   | String | optional |  `""`  |
 | <a id="zig_configure_test-host_threaded"></a>host_threaded |  The threaded setting for the host configuration, corresponds to the `-fsingle-threaded` Zig compiler flag.   | String | optional |  `""`  |
 | <a id="zig_configure_test-host_use_cc_common_link"></a>host_use_cc_common_link |  Whether to use cc_common.link to link zig binaries, tests and shared libraries in the host configuration. Possible values: [-1, 0, 1]. -1 means use current host configuration value for //zig/settings:host_use_cc_common_link. 0 means do not use cc_common.link (use zig build-exe instead). 1 means use cc_common.link.   | Integer | optional |  `-1`  |
 | <a id="zig_configure_test-host_zigopt"></a>host_zigopt |  Additional list of flags passed to the zig compiler for all Zig compile actions when building for the host configuration.<br><br>The flags specified by this setting do not override those specified via the `zigopts` attribute of `zig_*` rules. Instead, they are prepended to the command line before module specific flags.<br><br>This is an advanced feature that can conflict with attributes, build settings, and other flags defined by the toolchain itself. Use this at your own risk of hitting undefined behaviors.   | List of strings | optional |  `[]`  |
-| <a id="zig_configure_test-mode"></a>mode |  The build mode setting, corresponds to the `-O` Zig compiler flag.   | String | optional |  `""`  |
+| <a id="zig_configure_test-mode"></a>mode |  The build mode setting, corresponds to the `-O` Zig compiler flag. `auto` follows Bazel's `--compilation_mode`.   | String | optional |  `""`  |
 | <a id="zig_configure_test-target"></a>target |  The target platform, expects a label to a Bazel target platform used to select a `zig_target_toolchain` instance.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="zig_configure_test-threaded"></a>threaded |  The threaded setting, corresponds to the `-fsingle-threaded` Zig compiler flag.   | String | optional |  `""`  |
 | <a id="zig_configure_test-use_cc_common_link"></a>use_cc_common_link |  Whether to use cc_common.link to link zig binaries, tests and shared libraries. Possible values: [-1, 0, 1]. -1 means use current configuration value for //zig/settings:experimental_use_cc_common_link. 0 means do not use cc_common.link (use zig build-exe instead). 1 means use cc_common.link.   | Integer | optional |  `-1`  |
@@ -573,5 +579,3 @@ zig_test(
 | <a id="zig_test-strip_debug_symbols"></a>strip_debug_symbols |  Whether to pass '-fstrip' to the zig compiler to remove debug symbols.   | Boolean | optional |  `False`  |
 | <a id="zig_test-test_runner"></a>test_runner |  Optional Zig file to specify a custom test runner   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="zig_test-zigopts"></a>zigopts |  Additional list of flags passed to the zig compiler. Subject to location expansion.<br><br>This is an advanced feature that can conflict with attributes, build settings, and other flags defined by the toolchain itself. Use this at your own risk of hitting undefined behaviors.   | List of strings | optional |  `[]`  |
-
-

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -579,3 +579,5 @@ zig_test(
 | <a id="zig_test-strip_debug_symbols"></a>strip_debug_symbols |  Whether to pass '-fstrip' to the zig compiler to remove debug symbols.   | Boolean | optional |  `False`  |
 | <a id="zig_test-test_runner"></a>test_runner |  Optional Zig file to specify a custom test runner   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="zig_test-zigopts"></a>zigopts |  Additional list of flags passed to the zig compiler. Subject to location expansion.<br><br>This is an advanced feature that can conflict with attributes, build settings, and other flags defined by the toolchain itself. Use this at your own risk of hitting undefined behaviors.   | List of strings | optional |  `[]`  |
+
+

--- a/zig/config/mode/BUILD.bazel
+++ b/zig/config/mode/BUILD.bazel
@@ -1,29 +1,88 @@
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
 config_setting(
-    name = "debug",
+    name = "_debug_explicit",
     flag_values = {
         "//zig/settings:mode": "debug",
     },
 )
 
 config_setting(
-    name = "release_safe",
+    name = "_debug_auto_dbg",
+    flag_values = {
+        "//zig/settings:mode": "auto",
+    },
+    values = {
+        "compilation_mode": "dbg",
+    },
+)
+
+config_setting(
+    name = "_debug_auto_fastbuild",
+    flag_values = {
+        "//zig/settings:mode": "auto",
+    },
+    values = {
+        "compilation_mode": "fastbuild",
+    },
+)
+
+selects.config_setting_group(
+    name = "debug",
+    match_any = [
+        ":_debug_explicit",
+        ":_debug_auto_dbg",
+        ":_debug_auto_fastbuild",
+    ],
+)
+
+config_setting(
+    name = "_release_safe_explicit",
     flag_values = {
         "//zig/settings:mode": "release_safe",
     },
 )
 
+selects.config_setting_group(
+    name = "release_safe",
+    match_any = [":_release_safe_explicit"],
+)
+
 config_setting(
-    name = "release_small",
+    name = "_release_small_explicit",
     flag_values = {
         "//zig/settings:mode": "release_small",
     },
 )
 
+selects.config_setting_group(
+    name = "release_small",
+    match_any = [":_release_small_explicit"],
+)
+
 config_setting(
-    name = "release_fast",
+    name = "_release_fast_explicit",
     flag_values = {
         "//zig/settings:mode": "release_fast",
     },
+)
+
+config_setting(
+    name = "_release_fast_auto_opt",
+    flag_values = {
+        "//zig/settings:mode": "auto",
+    },
+    values = {
+        "compilation_mode": "opt",
+    },
+)
+
+selects.config_setting_group(
+    name = "release_fast",
+    match_any = [
+        ":_release_fast_explicit",
+        ":_release_fast_auto_opt",
+    ],
 )
 
 # Execute `bazel run //util:update_filegroups` to update this target.

--- a/zig/private/settings.bzl
+++ b/zig/private/settings.bzl
@@ -73,7 +73,13 @@ MODE_ARGS = {
     "release_fast": ["-O", "ReleaseFast"],
 }
 
-MODE_VALUES = ["debug", "release_safe", "release_small", "release_fast"]
+MODE_VALUES = ["auto", "debug", "release_safe", "release_small", "release_fast"]
+
+COMPILATION_MODE_TO_MODE = {
+    "dbg": "debug",
+    "fastbuild": "debug",
+    "opt": "release_fast",
+}
 
 THREADED_ARGS = {
     "multi": ["-fno-single-threaded"],
@@ -85,12 +91,23 @@ THREADED_VALUES = ["multi", "single"]
 def _is_exec_configuration(ctx):
     return ctx.genfiles_dir.path.find("-exec") != -1
 
+def _resolve_mode(ctx, mode):
+    if mode != "auto":
+        return mode
+
+    compilation_mode = ctx.var["COMPILATION_MODE"]
+    if compilation_mode not in COMPILATION_MODE_TO_MODE:
+        fail("Unrecognized Bazel compilation mode {}.".format(compilation_mode))
+
+    return COMPILATION_MODE_TO_MODE[compilation_mode]
+
 def _settings_impl(ctx):
     args = []
 
     is_exec_configuration = _is_exec_configuration(ctx)
 
     mode = ctx.attr.host_mode[BuildSettingInfo].value if is_exec_configuration else ctx.attr.mode[BuildSettingInfo].value
+    mode = _resolve_mode(ctx, mode)
     args.extend(MODE_ARGS[mode])
 
     threaded = ctx.attr.host_threaded[BuildSettingInfo].value if is_exec_configuration else ctx.attr.threaded[BuildSettingInfo].value

--- a/zig/private/zig_configure.bzl
+++ b/zig/private/zig_configure.bzl
@@ -10,6 +10,8 @@ Transitions a target and its dependencies to a different configuration.
 Settings like the build mode, e.g. `ReleaseSafe`, or the target platform,
 can be set on the command-line on demand,
 e.g. using `--@rules_zig//zig/settings:mode=release_safe`.
+By default, target build mode is `auto`: Bazel `dbg` and `fastbuild`
+compilation modes map to Zig `Debug`, and Bazel `opt` maps to Zig `ReleaseFast`.
 
 However, you may wish to always build a given target
 in a particular configuration,
@@ -208,12 +210,12 @@ def _make_attrs(*, executable):
             default = -1,
         ),
         "mode": attr.string(
-            doc = "The build mode setting, corresponds to the `-O` Zig compiler flag.",
+            doc = "The build mode setting, corresponds to the `-O` Zig compiler flag. `auto` follows Bazel's `--compilation_mode`.",
             mandatory = False,
             values = MODE_VALUES,
         ),
         "host_mode": attr.string(
-            doc = "The build mode setting for the host configuration, corresponds to the `-O` Zig compiler flag.",
+            doc = "The build mode setting for the host configuration, corresponds to the `-O` Zig compiler flag. `auto` follows Bazel's `--compilation_mode`.",
             mandatory = False,
             values = MODE_VALUES,
         ),

--- a/zig/settings/BUILD.bazel
+++ b/zig/settings/BUILD.bazel
@@ -33,7 +33,7 @@ bool_flag(
 
 string_flag(
     name = "mode",
-    build_setting_default = "debug",
+    build_setting_default = "auto",
     values = MODE_VALUES,
     visibility = ["//zig/config/mode:__pkg__"],
 )

--- a/zig/tests/config_test.bzl
+++ b/zig/tests/config_test.bzl
@@ -19,23 +19,32 @@ _string_value = rule(
     },
 )
 
-def _define_config_settings_test(*, flag, value):
+_COMPILATION_MODE = "//command_line_option:compilation_mode"
+
+def _define_config_settings_test(*, flag, value, expected_value = None, compilation_mode = None):
     def _test_impl(ctx):
         env = analysistest.begin(ctx)
 
         actual_value = analysistest.target_under_test(env)[_ValueInfo].value
-        asserts.equals(env, value, actual_value, "Unexpected value for {}".format(flag))
+        asserts.equals(env, expected_value or value, actual_value, "Unexpected value for {}".format(flag))
 
         return analysistest.end(env)
 
+    config_settings = {flag: value}
+    if compilation_mode:
+        config_settings[_COMPILATION_MODE] = compilation_mode
+
     return analysistest.make(
         _test_impl,
-        config_settings = {flag: value},
+        config_settings = config_settings,
     )
 
 _SETTINGS_MODE = canonical_label("@//zig/settings:mode")
 _SETTINGS_THREADED = canonical_label("@//zig/settings:threaded")
 
+_mode_auto_dbg_test = _define_config_settings_test(flag = _SETTINGS_MODE, value = "auto", expected_value = "debug", compilation_mode = "dbg")
+_mode_auto_fastbuild_test = _define_config_settings_test(flag = _SETTINGS_MODE, value = "auto", expected_value = "debug", compilation_mode = "fastbuild")
+_mode_auto_opt_test = _define_config_settings_test(flag = _SETTINGS_MODE, value = "auto", expected_value = "release_fast", compilation_mode = "opt")
 _mode_debug_test = _define_config_settings_test(flag = _SETTINGS_MODE, value = "debug")
 _mode_release_safe_test = _define_config_settings_test(flag = _SETTINGS_MODE, value = "release_safe")
 _mode_release_small_test = _define_config_settings_test(flag = _SETTINGS_MODE, value = "release_small")
@@ -71,6 +80,9 @@ def config_test_suite(name):
     unittest.suite(
         name,
         # mode
+        partial.make(_mode_auto_dbg_test, target_under_test = mode_name, size = "small"),
+        partial.make(_mode_auto_fastbuild_test, target_under_test = mode_name, size = "small"),
+        partial.make(_mode_auto_opt_test, target_under_test = mode_name, size = "small"),
         partial.make(_mode_debug_test, target_under_test = mode_name, size = "small"),
         partial.make(_mode_release_safe_test, target_under_test = mode_name, size = "small"),
         partial.make(_mode_release_small_test, target_under_test = mode_name, size = "small"),

--- a/zig/tests/integration_tests/integration_tests_runner.zig
+++ b/zig/tests/integration_tests/integration_tests_runner.zig
@@ -79,6 +79,19 @@ test "target build mode defaults to Debug" {
     try std.testing.expectEqualStrings("Debug", result.stdout);
 }
 
+test "target build mode follows Bazel opt compilation mode" {
+    const ctx = try BitContext.init();
+    defer ctx.deinit();
+
+    const result = try ctx.exec_bazel(.{
+        .argv = &[_][]const u8{ "run", "-c", "opt", "//:print_build_mode" },
+    });
+    defer result.deinit();
+
+    try std.testing.expect(result.success);
+    try std.testing.expectEqualStrings("ReleaseFast", result.stdout);
+}
+
 test "exec build mode defaults to ReleaseSafe" {
     const ctx = try BitContext.init();
     defer ctx.deinit();
@@ -100,7 +113,7 @@ test "target build mode can be set on the command line" {
     defer ctx.deinit();
 
     const result = try ctx.exec_bazel(.{
-        .argv = &[_][]const u8{ "run", "//:print_build_mode", "--@rules_zig//zig/settings:mode=release_small" },
+        .argv = &[_][]const u8{ "run", "-c", "opt", "--@rules_zig//zig/settings:mode=release_small", "//:print_build_mode" },
     });
     defer result.deinit();
 

--- a/zig/tests/mode_test.bzl
+++ b/zig/tests/mode_test.bzl
@@ -12,13 +12,20 @@ load(
 
 _SETTINGS_MODE = canonical_label("@//zig/settings:mode")
 _SETTINGS_HOST_MODE = canonical_label("@//zig/settings:host_mode")
+_COMPILATION_MODE = "//command_line_option:compilation_mode"
 
-def _define_settings_mode_test(mode, option):
+def _mode_config_settings(mode, compilation_mode = None):
+    config_settings = {_SETTINGS_MODE: mode}
+    if compilation_mode:
+        config_settings[_COMPILATION_MODE] = compilation_mode
+    return config_settings
+
+def _define_settings_mode_test(mode, option, expected_mode = None, compilation_mode = None):
     def _test_impl(ctx):
         env = analysistest.begin(ctx)
 
         settings = analysistest.target_under_test(env)[ZigSettingsInfo]
-        asserts.equals(env, mode, settings.mode)
+        asserts.equals(env, expected_mode or mode, settings.mode)
 
         mode_option = assert_find_unique_option(env, "-O", settings.args)
         asserts.equals(env, option, mode_option)
@@ -27,9 +34,12 @@ def _define_settings_mode_test(mode, option):
 
     return analysistest.make(
         _test_impl,
-        config_settings = {_SETTINGS_MODE: mode},
+        config_settings = _mode_config_settings(mode, compilation_mode),
     )
 
+_settings_mode_auto_dbg_test = _define_settings_mode_test("auto", "Debug", expected_mode = "debug", compilation_mode = "dbg")
+_settings_mode_auto_fastbuild_test = _define_settings_mode_test("auto", "Debug", expected_mode = "debug", compilation_mode = "fastbuild")
+_settings_mode_auto_opt_test = _define_settings_mode_test("auto", "ReleaseFast", expected_mode = "release_fast", compilation_mode = "opt")
 _settings_mode_debug_test = _define_settings_mode_test("debug", "Debug")
 _settings_mode_release_safe_test = _define_settings_mode_test("release_safe", "ReleaseSafe")
 _settings_mode_release_small_test = _define_settings_mode_test("release_small", "ReleaseSmall")
@@ -57,7 +67,7 @@ def _define_exec_settings_mode_test(target_mode, host_mode, host_option):
 
 _settings_exec_mode_test = _define_exec_settings_mode_test("debug", "release_fast", "ReleaseFast")
 
-def _define_build_mode_test(mnemonic, mode, option):
+def _define_build_mode_test(mnemonic, mode, option, compilation_mode = None):
     def _test_impl(ctx):
         env = analysistest.begin(ctx)
 
@@ -69,9 +79,13 @@ def _define_build_mode_test(mnemonic, mode, option):
 
     return analysistest.make(
         _test_impl,
-        config_settings = {_SETTINGS_MODE: mode},
+        config_settings = _mode_config_settings(mode, compilation_mode),
     )
 
+_build_exe_mode_auto_dbg_test = _define_build_mode_test("ZigBuildExe", "auto", "Debug", compilation_mode = "dbg")
+_build_exe_mode_auto_fastbuild_test = _define_build_mode_test("ZigBuildExe", "auto", "Debug", compilation_mode = "fastbuild")
+_build_exe_mode_auto_opt_test = _define_build_mode_test("ZigBuildExe", "auto", "ReleaseFast", compilation_mode = "opt")
+_build_exe_mode_release_small_opt_test = _define_build_mode_test("ZigBuildExe", "release_small", "ReleaseSmall", compilation_mode = "opt")
 _build_exe_mode_debug_test = _define_build_mode_test("ZigBuildExe", "debug", "Debug")
 _build_exe_mode_release_safe_test = _define_build_mode_test("ZigBuildExe", "release_safe", "ReleaseSafe")
 _build_exe_mode_release_small_test = _define_build_mode_test("ZigBuildExe", "release_small", "ReleaseSmall")
@@ -96,6 +110,9 @@ def mode_test_suite(name):
     unittest.suite(
         name,
         # Test Zig build mode on the settings target
+        partial.make(_settings_mode_auto_dbg_test, target_under_test = "//zig/settings", size = "small"),
+        partial.make(_settings_mode_auto_fastbuild_test, target_under_test = "//zig/settings", size = "small"),
+        partial.make(_settings_mode_auto_opt_test, target_under_test = "//zig/settings", size = "small"),
         partial.make(_settings_mode_debug_test, target_under_test = "//zig/settings", size = "small"),
         partial.make(_settings_mode_release_safe_test, target_under_test = "//zig/settings", size = "small"),
         partial.make(_settings_mode_release_small_test, target_under_test = "//zig/settings", size = "small"),
@@ -103,6 +120,10 @@ def mode_test_suite(name):
         # Test Zig exec build mode uses host_mode instead of mode
         partial.make(_settings_exec_mode_test, target_under_test = "//zig/tests:exec_settings", size = "small"),
         # Test Zig build mode on a binary target
+        partial.make(_build_exe_mode_auto_dbg_test, target_under_test = "//zig/tests/simple-binary:binary", size = "small"),
+        partial.make(_build_exe_mode_auto_fastbuild_test, target_under_test = "//zig/tests/simple-binary:binary", size = "small"),
+        partial.make(_build_exe_mode_auto_opt_test, target_under_test = "//zig/tests/simple-binary:binary", size = "small"),
+        partial.make(_build_exe_mode_release_small_opt_test, target_under_test = "//zig/tests/simple-binary:binary", size = "small"),
         partial.make(_build_exe_mode_debug_test, target_under_test = "//zig/tests/simple-binary:binary", size = "small"),
         partial.make(_build_exe_mode_release_safe_test, target_under_test = "//zig/tests/simple-binary:binary", size = "small"),
         partial.make(_build_exe_mode_release_small_test, target_under_test = "//zig/tests/simple-binary:binary", size = "small"),


### PR DESCRIPTION
Adds support for mapping Bazel --compilation_mode to Zig optimize modes when `//zig/settings:mode` is left at its new `auto` default:

- dbg / fastbuild -> Debug
- opt -> ReleaseFast