### PR TITLE
chore: fetch translate-c from GitHub

### DIFF
--- a/e2e/workspace/MODULE.bazel
+++ b/e2e/workspace/MODULE.bazel
@@ -32,9 +32,10 @@ http_archive(
 http_archive(
     name = "translate-c",
     build_file = "//third_party/translate-c:translate-c.bazel",
-    sha256 = "2f062a9e8baadf9e9e1a9460639175af727aa132237ca5ec7ea2435ea906f5a4",
-    strip_prefix = "translate-c",
-    url = "https://codeberg.org/ziglang/translate-c/archive/42f630117deffd5318b4a6ceffbd366dd0af8cee.tar.gz",
+    sha256 = "8a24b51b6f1fe1be643b68142077cb92e638b1cd02d58351ff0910a44db7dafd",
+    strip_prefix = "translate-c-42f630117deffd5318b4a6ceffbd366dd0af8cee",
+    # Upstream: https://codeberg.org/ziglang/translate-c/commit/42f630117deffd5318b4a6ceffbd366dd0af8cee
+    url = "https://github.com/aherrmann/translate-c/archive/42f630117deffd5318b4a6ceffbd366dd0af8cee.tar.gz",
 )
 
 register_toolchains("//third_party/translate-c:toolchain")


### PR DESCRIPTION
Codeberg downloads frequently fail, see below.

https://buildkite.com/bazel/bcr-presubmit/builds/35077/canvas?tab=output&jid=019e688d-5b25-4f18-aef9-52bee495bfa3#L379
```
(08:32:20) ERROR: /var/lib/buildkite-agent/.cache/bazel/_bazel_buildkite-agent/39a54ffe92ada093bb93e97d77eb0747/external/bazel_tools/tools/build_defs/repo/http.bzl:200:45: An error occurred during the fetch of repository '+http_archive+translate-c':
   Traceback (most recent call last):
	File "/var/lib/buildkite-agent/.cache/bazel/_bazel_buildkite-agent/39a54ffe92ada093bb93e97d77eb0747/external/bazel_tools/tools/build_defs/repo/http.bzl", line 200, column 45, in _http_archive_impl
		download_info = ctx.download_and_extract(
Error in download_and_extract: java.io.IOException: Error downloading [https://codeberg.org/ziglang/translate-c/archive/42f630117deffd5318b4a6ceffbd366dd0af8cee.tar.gz] to /var/lib/buildkite-agent/.cache/bazel/_bazel_buildkite-agent/39a54ffe92ada093bb93e97d77eb0747/external/+http_archive+translate-c/temp15172771316052087141/42f630117deffd5318b4a6ceffbd366dd0af8cee.tar.gz: Read timed out
(08:32:20) ERROR: no such package '@@+http_archive+translate-c//': java.io.IOException: Error downloading [https://codeberg.org/ziglang/translate-c/archive/42f630117deffd5318b4a6ceffbd366dd0af8cee.tar.gz] to /var/lib/buildkite-agent/.cache/bazel/_bazel_buildkite-agent/39a54ffe92ada093bb93e97d77eb0747/external/+http_archive+translate-c/temp15172771316052087141/42f630117deffd5318b4a6ceffbd366dd0af8cee.tar.gz: Read timed out
(08:32:20) ERROR: /var/lib/buildkite-agent/builds/bk-docker-gh68/bazel-org-repo-root/module_src/e2e/workspace/third_party/translate-c/BUILD.bazel:3:22: //third_party/translate-c:toolchain_impl depends on @@+http_archive+translate-c//:translate-c in repository @@+http_archive+translate-c which failed to fetch. no such package '@@+http_archive+translate-c//': java.io.IOException: Error downloading [https://codeberg.org/ziglang/translate-c/archive/42f630117deffd5318b4a6ceffbd366dd0af8cee.tar.gz] to /var/lib/buildkite-agent/.cache/bazel/_bazel_buildkite-agent/39a54ffe92ada093bb93e97d77eb0747/external/+http_archive+translate-c/temp15172771316052087141/42f630117deffd5318b4a6ceffbd366dd0af8cee.tar.gz: Read timed out
(08:32:20) ERROR: Analysis of target '//translate-c/transitive-cc-library-zig-binary:output_test_external_translate_c' failed; build aborted: Analysis failed
```
