### PR TITLE
chore: disable BCR draft PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,7 @@ jobs:
     with:
       tag_name: ${{ inputs.tag || github.ref_name }}
       registry_fork: hermeticbuild/bazel-central-registry
+      draft: false
     permissions:
       attestations: write
       contents: write


### PR DESCRIPTION
The PR is opened under the hermeticbuild-bot account, change PR status requires repository write access.
